### PR TITLE
Implement build-debian action

### DIFF
--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -1,0 +1,113 @@
+name: Build debian package
+description: Builds a debian package and uploads the artifact
+
+inputs:
+  source-dir:
+    required: false
+    description: Directory where the source is located
+  docker-image:
+    required: false
+    default: ubuntu:rolling
+    description: The docker image used to build the package
+  token:
+    required: false
+    description: If provided, used for git authentication in the source build
+
+
+# The process:
+# 1. We build the source package in a docker container with ca-certificates installed and thus,
+#    a useful internet connection.
+# 2. We the extract the source package.
+# 3. We build the .deb from the source package, in a container without ca-certificates (unless it
+#    is added as a build dependency), hence without a useful internet connection.
+#
+# To help with debugging, here are the processes and the directories they takes place in:
+#
+#  ${{ github.workspace }}
+#     ├── a/b/c/${{ inputs.source-dir }}
+#     │                 |
+#     │           Build source pkg
+#     │                 ↓
+#     ├── ${{ env.SOURCE_OUTPUT_DIR }}
+#     │                 |
+#     │          Extract source pkg
+#     │                 ↓
+#     ├── ${{ env.BUILD_INPUT_DIR }}
+#     │                 |
+#     │          Build debian pkg
+#     │                 ↓
+#     └── ${{ env.BUILD_OUTPUT_DIR }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up source package build
+      shell: bash
+      run: |
+        set -eu
+
+        echo "::group::Install devscripts"
+        DEBIAN_FRONTEND=noninteractive sudo apt install -y devscripts
+        echo "::endgroup::"
+
+        echo "::group::Append commit SHA to local version"
+        cd '${{ inputs.source-dir }}'
+        sanitized_docker=$( echo "${{ inputs.docker-image }}" | sed 's/://' )
+        debchange --local "+${sanitized_docker}+${{ github.sha }}" "Github build. Job id: ${{ github.run_id }}. Attempt: ${{ github.run_number }}."
+        echo "::endgroup::"
+
+        echo "::group::Parsing name and version"
+        echo PKG_NAME="$( dpkg-parsechangelog --show-field source )" >> $GITHUB_ENV
+        echo PKG_VERSION="$( dpkg-parsechangelog --show-field version )" >> $GITHUB_ENV
+        cd -
+        echo "::endgroup::"
+
+        echo "::group::Prepare source build"
+        echo SOURCE_OUTPUT_DIR="$( mktemp --directory --tmpdir=. )" >> $GITHUB_ENV
+        echo "::endgroup::"
+    - name: Build source package
+      uses: jtdor/build-deb-action@v1
+      with:
+        source-dir: ${{ inputs.source-dir }}
+        artifacts-dir: ${{ env.SOURCE_OUTPUT_DIR }}
+        docker-image: ${{ inputs.docker-image }}
+        buildpackage-opts: --build=source
+        extra-build-deps: ca-certificates git
+        before-build-hook: |
+          GITHUB_TOKEN="${{ inputs.token }}"
+          if [ -n "${GITHUB_TOKEN}" ]; then
+            git config --system url."https://api:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+          fi
+    - name: Set up package build
+      shell: bash
+      run: |
+        set -eu
+
+        echo "::group::Create build input directory"
+        # Appending /source because 'dpkg-source --extract' needs the output directory to be non-existent
+        BUILD_INPUT_DIR="$( mktemp --directory --tmpdir='.' )/source"
+        echo BUILD_INPUT_DIR="${BUILD_INPUT_DIR}" >> $GITHUB_ENV
+        echo "::endgroup::"
+        
+        echo "::group::Create build output directory"
+        echo BUILD_OUTPUT_DIR="$( mktemp --directory --tmpdir='.' )" >> $GITHUB_ENV
+        echo "::endgroup::"
+
+        echo "::group::Extract source package"
+        BUILD_INPUT_DIR=$(realpath "${BUILD_INPUT_DIR}")
+        cd ${{ env.SOURCE_OUTPUT_DIR }}
+        dpkg-source --extract *.dsc "${BUILD_INPUT_DIR}"
+        cd -
+        echo "::endgroup::"
+    - name: Build package
+      uses: jtdor/build-deb-action@v1
+      with:
+        artifacts-dir: ${{ env.BUILD_OUTPUT_DIR }}
+        source-dir: ${{ env.BUILD_INPUT_DIR }}
+        docker-image: ${{ inputs.docker-image }}
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.PKG_NAME }}_${{ env.PKG_VERSION }}
+        path: ${{ env.BUILD_OUTPUT_DIR }}/
+        if-no-files-found: error


### PR DESCRIPTION
This action builds a debian package at a specified path and uploads the artifacts generated. It is a wrapper around jtdor/build-deb-action, which itself uses dpkg.

It needs:
- the source dir: where the debian/ folder is located
- docker-image: where the package will be built, and as such the release to target
- token: This one is optional. If provided, it is used to grant git  access to private repos, which is necessary to fetch Go private packages

This action has been tested and is in use in a private repository of the Canonical organization.

UDENG-878