### PR TITLE
fix(github): Ensure correct group of people is set for reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @didrocks
-* @tim-hm
+* @didrocks @tim-hm


### PR DESCRIPTION
The codeowner file syntax is actually overriding previous rules and is not cumulative. We can assign owners for subparts of the trees, but without rule, this is a global override.
Then, ensure that both owners are assigned for review on this repository.