### PR TITLE
fix(gh-actions): Fix Windows issues in cross-platform Github actions

### DIFF
--- a/gh-actions/common/has-diff/action.yml
+++ b/gh-actions/common/has-diff/action.yml
@@ -29,7 +29,7 @@ runs:
         set -eu
 
         # Ignore requested file for changes
-        if [ -n "${{ inputs.paths-to-ignore }}" ]; then
+        if [ -n '${{ inputs.paths-to-ignore }}' ]; then
           files_to_ignore=$(ls ${{ inputs.paths-to-ignore }} 2>/dev/null || true)
           if [ -n "${files_to_ignore}" ]; then
             git update-index --assume-unchanged ${files_to_ignore}
@@ -50,7 +50,8 @@ runs:
 
         # Additional arguments to ignore.
         if [ -n "${{ inputs.regexp-to-ignore }}" ]; then
-          diffCmd="${diffCmd} --ignore-matching-lines '${{ inputs.regexp-to-ignore }}'"
+          regexp-to-ignore='${{ inputs.regexp-to-ignore }}'
+          diffCmd="${diffCmd} --ignore-matching-lines ${regexp-to-ignore}"
         fi
 
         DIFF=$(git difftool -y -x "${diffCmd}" .)

--- a/gh-actions/common/print-summary/action.yml
+++ b/gh-actions/common/print-summary/action.yml
@@ -33,7 +33,7 @@ runs:
           echo "| $2 | ${icon} |" >> $GITHUB_STEP_SUMMARY
         }
 
-        echo "### ${{ inputs.title }}" >> $GITHUB_STEP_SUMMARY
+        echo '### ${{ inputs.title }}' >> $GITHUB_STEP_SUMMARY
 
         echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
         echo "| --- | :---:  |" >> $GITHUB_STEP_SUMMARY
@@ -52,4 +52,4 @@ runs:
             res=${jobResult%%" "*}
             name=${jobResult#*" "}
             print_status_line "${res}" "${name}"
-        done <<< "${{ inputs.step-results }}"
+        done <<< '${{ inputs.step-results }}'

--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -182,12 +182,11 @@ runs:
     - name: Installing govulncheck
       if: ${{ always() && steps.tooling-version.outcome == 'success' }}
       id: install-govulncheck
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ runner.temp }}
       run: |
         echo Installing govulncheck
         set -eu
 
-        cd ${{ runner.temp }}
         go install golang.org/x/vuln/cmd/govulncheck@${{ steps.tooling-version.outputs.vulncheck }}
       shell: bash
     - name: Known vulnerabilities check

--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -57,24 +57,31 @@ runs:
 
         echo "version=${version}" >> $GITHUB_OUTPUT
       shell: bash
-
-    - name: Get arguments and version for golangci-lint
+    - name: Get tooling version
+      shell: bash
+      id: tooling-version
       if: ${{ always() && steps.go-version.outcome == 'success' }}
+      working-directory: ${{ inputs.tools-directory }}
+      run: |
+        function set-version {
+          name=$1
+          path=$2
+          version="$(
+            go mod edit --json | jq -r ".Require[] | select(.Path==\"${path}\") | .Version" || echo 'latest'
+          )"
+          echo "${name}=${version}" >> $GITHUB_OUTPUT
+        }
+
+        set-version "golangci-lint" "github.com/golangci/golangci-lint"
+        set-version "vulncheck" "golang.org/x/vuln"
+    - name: Get arguments and version for golangci-lint
+      if: ${{ always() && steps.tooling-version.outcome == 'success' }}
       id: golanci-lint
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         echo Get arguments and version for golangci-lint
         set -eu
-
-        version="latest"
-        if [ -n '${{ inputs.tools-directory }}' ]; then
-          cd '${{ inputs.tools-directory }}'
-          modVersion="$(go mod edit --json | jq -r '.Require[] | select(.Path=="github.com/golangci/golangci-lint") | .Version' || true)"
-          [ -n "${modVersion}" ] && version=${modVersion}
-          cd - > /dev/null
-        fi
-        echo "version=${version}" >> $GITHUB_OUTPUT
 
         # Detect which config file to use
         config='${{ github.action_path }}/.golangci-lint'
@@ -113,7 +120,7 @@ runs:
       id: golangci-lint-check
       uses: golangci/golangci-lint-action@v3
       with:
-        version: ${{ steps.golanci-lint.outputs.version }}
+        version: ${{ steps.tooling-version.outputs.golangci-lint }}
         args: ${{ steps.golanci-lint.outputs.args }}
         working-directory: ${{ inputs.working-directory }}
 
@@ -173,25 +180,15 @@ runs:
       shell: bash
 
     - name: Installing govulncheck
-      if: ${{ always() && steps.go-version.outcome == 'success' }}
+      if: ${{ always() && steps.tooling-version.outcome == 'success' }}
       id: install-govulncheck
       working-directory: ${{ inputs.working-directory }}
       run: |
         echo Installing govulncheck
         set -eu
 
-        # Get version to install if any
-        version="latest"
-        if [ -n '${{ inputs.tools-directory }}' ]; then
-          cd '${{ inputs.tools-directory }}'
-          modVersion="$(go mod edit --json | jq -r '.Require[] | select(.Path=="golang.org/x/vuln") | .Version' || true)"
-          [ -n "${modVersion}" ] && version=${modVersion}
-          cd - > /dev/null
-        fi
-
         cd ${{ runner.temp }}
-        go install golang.org/x/vuln/cmd/govulncheck@${version}
-        cd --
+        go install golang.org/x/vuln/cmd/govulncheck@${{ steps.tooling-version.outputs.vulncheck }}
       shell: bash
     - name: Known vulnerabilities check
       if: ${{ always() && steps.install-govulncheck.outcome == 'success' }}

--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -98,7 +98,7 @@ runs:
         echo "args=${args}" >> $GITHUB_OUTPUT
 
     - name: Workaround for golangci-lint bug
-      if: ${{ always() && steps.golanci-lint.outcome == 'success' }}
+      if: ${{ always() && steps.golanci-lint.outcome == 'success' && runner.os == 'Linux' }}
       shell: bash
       # This step is separated from the previous one because we need to be at the repository root
       run: |

--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -78,7 +78,11 @@ runs:
       # This step is separated from the previous one because we need to be at the repository root
       run: |
         # A terrible workaround for https://github.com/golangci/golangci-lint-action/issues/135
-        sudo chmod -R +w ../../../go/
+
+        # Avoid using sudo (it is unavailable in docker)
+        sudo --version &> /dev/null && SUDO="sudo" || SUDO=""
+
+        $SUDO chmod -R +w ../../../go/
     - name: Code formatting, vet, static checker Security…
       if: ${{ always() && steps.golanci-lint.outcome == 'success' }}
       id: golangci-lint-check

--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -77,13 +77,13 @@ runs:
         echo "version=${version}" >> $GITHUB_OUTPUT
 
         # Detect which config file to use
-        config=${{ github.action_path }}/.golangci-lint
+        config='${{ github.action_path }}/.golangci-lint'
         if [ -f ".golangci-lint" ]; then
           config=".golangci-lint"
         fi
-        if [ -n "${{ inputs.golangci-lint-configfile }}" ]; then
+        if [ -n '${{ inputs.golangci-lint-configfile }}' ]; then
           echo "Using project local config file"
-          config="${{ inputs.golangci-lint-configfile }}"
+          config='${{ inputs.golangci-lint-configfile }}'
         fi
         args="--config ${config}"
 
@@ -91,8 +91,9 @@ runs:
         args="${args} --go ${{ steps.go-version.outputs.version }}"
 
         # Optional build tag go-tags
-        if [ -n "${{ inputs.go-tags }}" ]; then
-          args="${args} --build-tags=${{ inputs.go-tags }}"
+        tags='${{ inputs.go-tags }}'
+        if [ -n "${tags}" ]; then
+          args="${args} --build-tags=${tags}"
         fi
         echo "args=${args}" >> $GITHUB_OUTPUT
 
@@ -154,7 +155,7 @@ runs:
         echo Build any binaries
         set -eu
 
-        if [ -n "${{ inputs.go-build-script }}" ]; then
+        if [ -n '${{ inputs.go-build-script }}' ]; then
           buildTest=$(mktemp)
           cat > ${buildTest} <<SCRIPTEOF
             ${{ inputs.go-build-script }}
@@ -163,7 +164,7 @@ runs:
           exit 0
         fi
 
-        tags="${{ inputs.go-tags }}"
+        tags='${{ inputs.go-tags }}'
         if [ -n "${tags}" ]; then
           tags="-tags=${tags}"
         fi
@@ -200,7 +201,7 @@ runs:
         echo Checking known vulnerabilities
         set -eu
 
-        tags="${{ inputs.go-tags }}"
+        tags='${{ inputs.go-tags }}'
         if [ -n "${tags}" ]; then
           tags="-tags=${tags}"
         fi

--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -25,6 +25,19 @@ runs:
         go-version-file: ${{ inputs.working-directory }}/go.mod
         check-latest: true
         cache: false
+    - name: Set up jq
+      shell: bash
+      run: |
+        echo "::group::Download jq"
+        if [ "${{runner.os}}" = "Windows" ]; then
+          winget.exe install jqlang.jq --accept-source-agreements --accept-package-agreements --silent --verbose || true
+        else
+          sudo --version &> /dev/null && SUDO="sudo" || SUDO=""
+          DEBIAN_FRONTEND=noninteractive $SUDO apt update
+          DEBIAN_FRONTEND=noninteractive $SUDO apt install jq
+        fi
+        echo "::endgroup::"
+        jq --version
     - name: Detect go version to use
       id: go-version
       working-directory: ${{ inputs.working-directory }}
@@ -32,7 +45,17 @@ runs:
         echo Detect go version to use
         set -eu
 
-        echo "version=$(grep '^go ' go.mod | cut -f2 -d' ')" >> $GITHUB_OUTPUT
+        json=$(go mod edit --json 2>&1 || go work edit --json 2>&1)
+        if [[ "$?" != 0 ]]; then
+          echo "Could not find go.mod or go.work files:"
+          echo $json
+          exit 1
+        fi
+
+        version=$(echo $json | jq -r '.Go')
+        echo "Go version ${version}"
+
+        echo "version=${version}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Get arguments and version for golangci-lint
@@ -44,11 +67,12 @@ runs:
         echo Get arguments and version for golangci-lint
         set -eu
 
-        # This handles "require foo version" and "require (\nfoo version\n)"" formats
         version="latest"
-        if [ -n "${{ inputs.tools-directory }}" ]; then
-          modVersion="$(grep golangci-lint ${{ inputs.tools-directory }}/go.mod | rev | cut -f1 -d' ' | rev || true)"
+        if [ -n '${{ inputs.tools-directory }}' ]; then
+          cd '${{ inputs.tools-directory }}'
+          modVersion="$(go mod edit --json | jq -r '.Require[] | select(.Path=="github.com/golangci/golangci-lint") | .Version' || true)"
           [ -n "${modVersion}" ] && version=${modVersion}
+          cd - > /dev/null
         fi
         echo "version=${version}" >> $GITHUB_OUTPUT
 
@@ -156,11 +180,12 @@ runs:
         set -eu
 
         # Get version to install if any
-        # This handles "require foo version" and "require (\nfoo version\n)"" formats
         version="latest"
-        if [ -n "${{ inputs.tools-directory }}" ]; then
-          modVersion="$(grep govulncheck ${{ inputs.tools-directory }}/go.mod | rev | cut -f1 -d' ' | rev || true)"
+        if [ -n '${{ inputs.tools-directory }}' ]; then
+          cd '${{ inputs.tools-directory }}'
+          modVersion="$(go mod edit --json | jq -r '.Require[] | select(.Path=="golang.org/x/vuln") | .Version' || true)"
           [ -n "${modVersion}" ] && version=${modVersion}
+          cd - > /dev/null
         fi
 
         cd ${{ runner.temp }}

--- a/gh-actions/go/generate/action.yaml
+++ b/gh-actions/go/generate/action.yaml
@@ -31,7 +31,7 @@ runs:
         echo Install tools and dependencies
         set -eu
 
-        cd ${{ inputs.tools-directory }}
+        cd '${{ inputs.tools-directory }}'
         tools=$(grep -o '_ ".*"' *.go | cut -d '"' -f 2)
 
         needsProtoc=false

--- a/gh-actions/go/generate/action.yaml
+++ b/gh-actions/go/generate/action.yaml
@@ -26,12 +26,11 @@ runs:
   steps:
     - name: Install tools and dependencies
       id: proto-deps
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: ${{ inputs.tools-directory }}
       run: |
         echo Install tools and dependencies
         set -eu
 
-        cd '${{ inputs.tools-directory }}'
         tools=$(grep -o '_ ".*"' *.go | cut -d '"' -f 2)
 
         needsProtoc=false
@@ -41,8 +40,6 @@ runs:
           fi
           go install ${tool}
         done
-
-        cd --
       shell: bash
     - name: Install latest protoc
       uses: arduino/setup-protoc@v2

--- a/gh-actions/go/generate/action.yaml
+++ b/gh-actions/go/generate/action.yaml
@@ -28,7 +28,7 @@ runs:
       id: proto-deps
       working-directory: ${{ inputs.tools-directory }}
       run: |
-        echo Install tools and dependencies
+        echo "::group::Install tools and dependencies"
         set -eu
 
         tools=$(grep -o '_ ".*"' *.go | cut -d '"' -f 2)
@@ -40,6 +40,8 @@ runs:
           fi
           go install ${tool}
         done
+
+        echo "::endgroup::"
       shell: bash
     - name: Install latest protoc
       uses: arduino/setup-protoc@v2


### PR DESCRIPTION
Strictly necessary:
- (85a1bbc) `sudo` is not available on Windows.
- (e3c87d8) `rev` is not available on Windows. I switched to using jq to parse go mod files.
- (5996fb2) Treat Linux-specific workarounds with more finesse.
- (d88da61, 9068ca3) Windows path arguments are passed `\with\back\slashes` which are read by bash as `withbackslashes`, making all usage of `cd` fail.

A couple QoL things:
- (2c5235b) Use single quotes around '${{ github.variable }}' to avoid weird interactions with special characters (were possible). Github pretty much acts like the C pre-processor here.
- (e5d5938) Added a ::group:: were I saw `apt` spam.

---
UDENG-1399
