### PR TITLE
feat(gh-actions): implement validate-pr-title action

### DIFF
--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -1,0 +1,13 @@
+name: Validate pull request title
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: canonical/desktop-engineering/gh-actions/common/validate-pr-title@main

--- a/gh-actions/common/validate-pr-title/action.yaml
+++ b/gh-actions/common/validate-pr-title/action.yaml
@@ -1,0 +1,103 @@
+name: Validate pull request title
+description: Ensures the title of the pull request complies with naming policy
+
+outputs:
+  tag:
+    description: 'The tag parsed from the PR title'
+    value: ${{ steps.parse.outputs.tag }}
+  component:
+    description: 'The component parsed from the PR title'
+    value: ${{ steps.parse.outputs.component }}
+  title:
+    description: 'The title parsed from the PR title'
+    value: ${{ steps.parse.outputs.title }}
+
+runs:
+  using: composite
+  steps:
+    - name: Parse PR title
+      id: parse
+      shell: bash
+      env:
+        # These variables are defined here so that they can be used verbatim,
+        # without this bash attempting to perform substitutions or character
+        # escapes. The last thing a regex needs is more escaped characters.
+        pattern: >-
+          ^([^() ]+)(\([^() ]+\))?: ([^ ].*)$
+        #   ~~~~~~~  ~~~~~~~~~~~    ~~~~~~~~
+        #   │        │              └─Title: free text after a colon and a single space.
+        #   │        └─Component: inside parentheses, optional.
+        #   └─Tag: limited to those pre-approved (see steps.validate.env.valid_tags).
+        pr_title: ${{ github.event.pull_request.title }}
+      run: |
+        # Parse ${{ github.event.pull_request.title }}
+        set -eu
+
+        echo "${pr_title}" | grep -P "${pattern}" > /dev/null || {
+            echo "::error::Pull request title does not match regex ${pattern}"
+            exit 1
+        }
+
+        output=$'\\1\t\\2\t\\3'
+        fields=$(perl -pe "s#${pattern}#${output}#" <<< "${pr_title}")
+        IFS=$'\t' read -r first second third <<< $fields
+
+        if [ -n "${third}" ]; then
+            echo "tag=${first}"               >> $GITHUB_OUTPUT
+            echo "component=${second:1:-1}"   >> $GITHUB_OUTPUT
+            echo "title=${third}"             >> $GITHUB_OUTPUT
+        else
+            echo "tag=${first}"               >> $GITHUB_OUTPUT
+            echo "component=''"               >> $GITHUB_OUTPUT
+            echo "title=${second}"            >> $GITHUB_OUTPUT
+        fi
+    - name: Validate tag
+      shell: bash
+      id: validate
+      env:
+        tag: ${{ steps.parse.outputs.tag }}
+        valid_tags: build deps ci docs feat fix maint perf refactor test
+      run: |
+        # Validate ${{ env.tag }}
+        set -eu
+
+        # Covert to list so that we can check each word separatelly
+        valid_tags=( ${{ env.valid_tags }} )
+
+        # Grep ^tag$ against every valid tag
+        printf '%s\n' "${valid_tags[@]}"                                           \
+            | grep  "^${tag}\$"  > /dev/null                                       \
+            || {
+                echo "::error::'$tag' is not in the list of admissible tags"
+                echo "Use any of:"
+                printf ' - %s\n' "${valid_tags[@]}"
+                exit 1
+            }
+    - name: Print result
+      shell: bash
+      if: always() && steps.parse.outcome == 'success'
+      env:
+        tag: ${{ steps.parse.outputs.tag }}
+        component: ${{ steps.parse.outputs.component }}
+        title: ${{ steps.parse.outputs.title }}
+      run: |
+        # Print table
+        set -eu
+
+        case ${{ steps.validate.outcome }} in
+          "success")
+            icon=":green_circle:"
+            ;;
+          "failure")
+            icon=":red_circle:"
+            ;;
+          "skipped")
+            icon=":white_circle:"
+            ;;
+          *)
+            icon=":question:"
+        esac
+
+        echo "| Tag            | Component    | Title      |"  >> $GITHUB_STEP_SUMMARY
+        echo "| -------------- | ------------ | ---------- |"  >> $GITHUB_STEP_SUMMARY
+        echo "| ${tag} ${icon} | ${component} | ${title}   |"  >> $GITHUB_STEP_SUMMARY

--- a/gh-actions/common/validate-pr-title/action.yaml
+++ b/gh-actions/common/validate-pr-title/action.yaml
@@ -43,7 +43,7 @@ runs:
       id: validate
       env:
         tag: ${{ steps.parse.outputs.tag }}
-        valid_tags: build deps ci docs feat fix maint perf refactor test
+        valid_tags: build deps ci docs feat fix maint perf refactor tests
       run: |
         # Validate ${{ env.tag }}
         set -eu

--- a/gh-actions/common/validate-pr-title/action.yaml
+++ b/gh-actions/common/validate-pr-title/action.yaml
@@ -24,6 +24,14 @@ runs:
 
         echo "${pr_title}" | grep -P "${pattern}" > /dev/null || {
             echo "::error::Pull request title does not match regex ${pattern}"
+
+            # Printing as a summary because multiline error messages are not supported
+            echo "Pull request title does not match regex \`${pattern}\`"                 >> $GITHUB_STEP_SUMMARY
+            echo "Example titles:"                                                        >> $GITHUB_STEP_SUMMARY
+            echo " - deps(turboencabulator): updated logarithmic casing"                  >> $GITHUB_STEP_SUMMARY
+            echo " - feat(guidance): enable location tracking via knowing where it isn't" >> $GITHUB_STEP_SUMMARY
+            echo " - docs: clarified behaviour of liblaurem in ipsum-compatible machines" >> $GITHUB_STEP_SUMMARY
+            echo " - maint: fix typo in example title"                                    >> $GITHUB_STEP_SUMMARY
             exit 1
         }
 

--- a/gh-actions/common/validate-pr-title/action.yaml
+++ b/gh-actions/common/validate-pr-title/action.yaml
@@ -40,7 +40,7 @@ runs:
         # Validate ${{ env.tag }}
         set -eu
 
-        # Covert to list so that we can check each word separatelly
+        # Convert to list so that we can check each word separatelly
         valid_tags=( ${{ env.valid_tags }} )
 
         # Grep ^tag$ against every valid tag
@@ -48,7 +48,7 @@ runs:
           exit 0
         fi
 
-        # Print result failure
+        # Failure: print results and help
         echo "::error::'${{ env.tag }}' is not in the list of admissible tags"
 
         # Printing as a summary because multiline error messages are not supported

--- a/gh-actions/common/validate-pr-title/action.yaml
+++ b/gh-actions/common/validate-pr-title/action.yaml
@@ -1,17 +1,6 @@
 name: Validate pull request title
 description: Ensures the title of the pull request complies with naming policy
 
-outputs:
-  tag:
-    description: 'The tag parsed from the PR title'
-    value: ${{ steps.parse.outputs.tag }}
-  component:
-    description: 'The component parsed from the PR title'
-    value: ${{ steps.parse.outputs.component }}
-  title:
-    description: 'The title parsed from the PR title'
-    value: ${{ steps.parse.outputs.title }}
-
 runs:
   using: composite
   steps:
@@ -38,19 +27,9 @@ runs:
             exit 1
         }
 
-        output=$'\\1\t\\2\t\\3'
-        fields=$(perl -pe "s#${pattern}#${output}#" <<< "${pr_title}")
-        IFS=$'\t' read -r first second third <<< $fields
-
-        if [ -n "${third}" ]; then
-            echo "tag=${first}"               >> $GITHUB_OUTPUT
-            echo "component=${second:1:-1}"   >> $GITHUB_OUTPUT
-            echo "title=${third}"             >> $GITHUB_OUTPUT
-        else
-            echo "tag=${first}"               >> $GITHUB_OUTPUT
-            echo "component=''"               >> $GITHUB_OUTPUT
-            echo "title=${second}"            >> $GITHUB_OUTPUT
-        fi
+        output=$'\\1'
+        tag=$(perl -pe "s#${pattern}#${output}#" <<< "${pr_title}")
+        echo "tag=${tag}" >> $GITHUB_OUTPUT
     - name: Validate tag
       shell: bash
       id: validate
@@ -65,39 +44,16 @@ runs:
         valid_tags=( ${{ env.valid_tags }} )
 
         # Grep ^tag$ against every valid tag
-        printf '%s\n' "${valid_tags[@]}"                                           \
-            | grep  "^${tag}\$"  > /dev/null                                       \
-            || {
-                echo "::error::'$tag' is not in the list of admissible tags"
-                echo "Use any of:"
-                printf ' - %s\n' "${valid_tags[@]}"
-                exit 1
-            }
-    - name: Print result
-      shell: bash
-      if: always() && steps.parse.outcome == 'success'
-      env:
-        tag: ${{ steps.parse.outputs.tag }}
-        component: ${{ steps.parse.outputs.component }}
-        title: ${{ steps.parse.outputs.title }}
-      run: |
-        # Print table
-        set -eu
+        if printf '%s\n' "${valid_tags[@]}" | grep "^${tag}\$" > /dev/null ; then
+          exit 0
+        fi
 
-        case ${{ steps.validate.outcome }} in
-          "success")
-            icon=":green_circle:"
-            ;;
-          "failure")
-            icon=":red_circle:"
-            ;;
-          "skipped")
-            icon=":white_circle:"
-            ;;
-          *)
-            icon=":question:"
-        esac
+        # Print result failure
+        echo "::error::'${{ env.tag }}' is not in the list of admissible tags"
 
-        echo "| Tag            | Component    | Title      |"  >> $GITHUB_STEP_SUMMARY
-        echo "| -------------- | ------------ | ---------- |"  >> $GITHUB_STEP_SUMMARY
-        echo "| ${tag} ${icon} | ${component} | ${title}   |"  >> $GITHUB_STEP_SUMMARY
+        # Printing as a summary because multiline error messages are not supported
+        echo "'${{ env.tag }}' is not in the list of admissible tags" >> $GITHUB_STEP_SUMMARY
+        echo "Valid tags are:"                                        >> $GITHUB_STEP_SUMMARY
+        printf ' - %s\n' "${valid_tags[@]}"                           >> $GITHUB_STEP_SUMMARY
+
+        exit 1


### PR DESCRIPTION
This pull request implements a Github action to validate pull request titles. It ensures that it follows schema `tag(optional-component): Some description`, and then ensures that the tag is in the pre-approved list.

As far as I understand, the workflow won't be triggered during this PR, as in needs to be in the main branch. I did some testing in another repo though, You can see and example PR and some workflow runs here: https://github.com/EduardGomezEscandell/test/pull/1

---
UDENG-1510