### PR TITLE
feat: Provide option to provide pro-token to setup-grpc action

### DIFF
--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -16,6 +16,11 @@ inputs:
   generate-diff-paths-to-ignore:
     description: Files and paths to ignore when checking if generated files changed. This is passed to git update-index.
     default: po/* doc/*.md README.md
+  github-token:
+    description: |
+      Your repository's GitHub token. Only necessary to circumvent GitHub API rate limits.
+      See the documentation for arduino/setup-protoc for more details.
+    default: ''
 
 runs:
   using: "composite"
@@ -154,6 +159,7 @@ runs:
       # https://github.com/orgs/community/discussions/25246
       uses: canonical/desktop-engineering/gh-actions/go/generate@main
       with:
+        github-token: ${{ inputs.github-token }}
         tools-directory: ${{ inputs.tools-directory }}
         paths-to-ignore: ${{ inputs.generate-diff-paths-to-ignore }}
         working-directory: ${{ inputs.working-directory }}

--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -157,7 +157,7 @@ runs:
       if: ${{ always() && steps.go-version.outcome == 'success' }}
       id: go-generate-check
       # https://github.com/orgs/community/discussions/25246
-      uses: canonical/desktop-engineering/gh-actions/go/generate@main
+      uses: canonical/desktop-engineering/gh-actions/go/generate@setup-grpc-github-token
       with:
         github-token: ${{ inputs.github-token }}
         tools-directory: ${{ inputs.tools-directory }}

--- a/gh-actions/go/generate/action.yaml
+++ b/gh-actions/go/generate/action.yaml
@@ -16,6 +16,11 @@ inputs:
   fail-on-diff:
     description: Fail the job on any detected diff.
     default: "true"
+  github-token:
+    description: |
+      Your repository's GitHub token. Only necessary to circumvent GitHub API rate limits.
+      See the documentation for arduino/setup-protoc for more details.
+    default: ''
 outputs:
   diff:
     description: Returns if there is a local diff.
@@ -46,6 +51,8 @@ runs:
     - name: Install latest protoc
       uses: arduino/setup-protoc@v2
       if: ${{ steps.proto-deps.outputs.needs-protoc == 'true' }}
+      with:
+        repo-token: ${{ inputs.github-token }}
     - name: Regenerate files with go generate
       id: go-generate-run
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
The `arduino/setup-protoc` action uses GitHub API rather than regular workflows. The GitHub API, however, is limited for non-registered users.

This PR allows the caller to specify their GitHub token so that these rates limits are increased.