### PR TITLE
deps: Update actions/upload-artifact from v3 to v4

### DIFF
--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -107,7 +107,7 @@ runs:
         source-dir: ${{ env.BUILD_INPUT_DIR }}
         docker-image: ${{ inputs.docker-image }}
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.PKG_NAME }}_${{ env.PKG_VERSION }}
         path: ${{ env.BUILD_OUTPUT_DIR }}/


### PR DESCRIPTION
Very sneaky line in the docs of download-artifact@v4:

> Downloading artifacts that were created from
  action/upload-artifact@v3 and below are not supported.

https://github.com/actions/download-artifact/tree/v4/?tab=readme-ov-file#breaking-changes