### PR TITLE
fix(gh-actions): update documentation path in Go code sanity check

### DIFF
--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -15,7 +15,7 @@ inputs:
     description: Which config file to check for golangci-lint. If not set, it will look for .golangci-lint in your project, or default to desktop team defaults.
   generate-diff-paths-to-ignore:
     description: Files and paths to ignore when checking if generated files changed. This is passed to git update-index.
-    default: po/* doc/*.md README.md
+    default: po/* docs/**/*.md README.md
 
 runs:
   using: "composite"


### PR DESCRIPTION
Now that we migrated to Read The Docs for project documentation, the directory name changed from `doc` to `docs`, and Markdown files are no longer guaranteed to be at the root of the directory.

Update the default paths for the Go sanity check to reflect this.