### PR TITLE
feat: add code sanity action for Rust

### DIFF
--- a/gh-actions/rust/code-sanity/action.yaml
+++ b/gh-actions/rust/code-sanity/action.yaml
@@ -1,0 +1,68 @@
+name: Rust code sanity check
+description: Checks code against our desktop Rust code quality and process standards.
+
+inputs:
+  token:
+    required: true
+    description: GitHub token required to authenticate certain Rust steps (used to make API calls)
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions-rs/toolchain@v1
+      id: toolchain
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: rustfmt, clippy
+    - name: Build crate
+      id: build-check
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --all-features
+    - name: Check code format with rustfmt
+      id: rustfmt-check
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+    - name: Check code format with clippy
+      id: clippy-check
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ inputs.token }}
+        args: --all-features
+    - name: Check for vulnerabilities with cargo-audit
+      id: cargo-audit-check
+      uses: actions-rs/audit-check@v1
+      with:
+        token: ${{ inputs.token }}
+    - name: Compute title of summary
+      if: ${{ always() && steps.toolchain.outcome == 'success' }}
+      id: compute-summary-title
+      run: |
+        echo Compute title of summary based on current directory
+        set -eu
+
+        title="Code sanity summary"
+
+        workspace=${{ github.workspace }}
+        dir=$(pwd)
+        dir=${dir#"${workspace}"}
+        if [ -n "${dir}" ]; then
+          title="${title} on ${dir}"
+        fi
+        echo "title=${title}" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Summary
+      if: ${{ always() && steps.compute-summary-title.outcome == 'success' }}
+      # https://github.com/orgs/community/discussions/25246
+      uses: canonical/desktop-engineering/gh-actions/common/print-summary@main
+      with:
+        title: ${{ steps.compute-summary-title.outputs.title }}
+        step-results: |
+          ${{ steps.clippy-check.outcome }} Linting with clippy
+          ${{ steps.rustfmt-check.outcome }} Formatting with rustfmt
+          ${{ steps.build-check.outcome }} Build
+          ${{ steps.cargo-audit-check.outcome }} Vulnerability scanning with cargo-audit


### PR DESCRIPTION
Similar to our Go action, add one for Rust that integrates the steps from [authd](https://github.com/ubuntu/authd/blob/e6f2ac656fb8e6069bbd4691090acfff2a07d727/.github/workflows/qa.yaml#L70-L89), adding an additional cargo-audit step.

Action in action: https://github.com/GabrielNagy/authd/actions/runs/7975090675

Fixes UDENG-2233