### PR TITLE
feat(build-debian): Use docker to manually run build and prepare steps and add tests

### DIFF
--- a/.github/workflows/test-build-deb.yaml
+++ b/.github/workflows/test-build-deb.yaml
@@ -84,3 +84,4 @@ jobs:
         with:
           source-dir: ./hello-src
           docker-image: ubuntu:devel
+          extra-source-build-deps: ''

--- a/.github/workflows/test-build-deb.yaml
+++ b/.github/workflows/test-build-deb.yaml
@@ -1,0 +1,87 @@
+name: Test build debian package
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - gh-actions/common/build-debian/**
+      - .github/workflows/test-build-deb*
+  pull_request:
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+  DEBCONF_NONINTERACTIVE_SEEN: true
+
+jobs:
+  build_native_deb:
+    name: Test build native debian package
+    runs-on: ubuntu-latest
+    outputs:
+      pkg-name: ${{ env.PKG_NAME }}
+      pkg-version: ${{ env.PKG_VERSION }}
+
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install ubuntu-dev-tools
+
+      - name: Get and prepare package source
+        run: |
+          set -eu
+
+          echo "::group::Get source"
+          pull-lp-source --download-only hello
+          dpkg-source -x hello*.dsc hello-src
+          rm -rf hello_*
+          mv -v hello-src/* .
+          echo "::endgroup::"
+
+          echo "::group::Mark package as a native package"
+          echo "3.0 (native)" > debian/source/format
+          dch -v$(dpkg-parsechangelog -S Version | cut -f1 -d-).1 \
+            "Mark as native package"
+          echo "::endgroup::"
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: .source
+
+      - name: Build package
+        uses: ./.source/gh-actions/common/build-debian
+        with:
+          docker-image: ubuntu:devel
+
+  build_source_deb:
+    name: Test build quilt debian package
+    runs-on: ubuntu-latest
+    outputs:
+      pkg-name: ${{ env.PKG_NAME }}
+      pkg-version: ${{ env.PKG_VERSION }}
+
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install ubuntu-dev-tools
+
+      - name: Get package source
+        run: |
+          set -eu
+
+          pull-lp-source --download-only hello
+          dpkg-source -x hello*.dsc hello-src
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: .source
+
+      - name: Build package
+        uses: ./.source/gh-actions/common/build-debian
+        with:
+          source-dir: ./hello-src
+          docker-image: ubuntu:devel
+        continue-on-error: true

--- a/.github/workflows/test-build-deb.yaml
+++ b/.github/workflows/test-build-deb.yaml
@@ -84,4 +84,3 @@ jobs:
         with:
           source-dir: ./hello-src
           docker-image: ubuntu:devel
-        continue-on-error: true

--- a/.github/workflows/test-build-deb.yaml
+++ b/.github/workflows/test-build-deb.yaml
@@ -60,6 +60,8 @@ jobs:
     outputs:
       pkg-name: ${{ env.PKG_NAME }}
       pkg-version: ${{ env.PKG_VERSION }}
+      source-pkg: ${{ steps.build-debian-source-package-upload-step.outputs.artifact-url }}
+      binaries: ${{ steps.build-debian-binary-packages-upload-step.outputs.artifact-url }}
 
     steps:
       - name: Install dependencies

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -158,6 +158,7 @@ runs:
 
     - name: Uploading source packages
       uses: actions/upload-artifact@v4
+      id: build-debian-source-package-upload-step
       with:
         name: ${{ env.PKG_NAME }}_${{ env.PKG_VERSION }}-debian-source
         path: ${{ env.SOURCE_OUTPUT_DIR }}/
@@ -244,6 +245,7 @@ runs:
           echo "::endgroup::"
 
     - name: Upload artifacts
+      id: build-debian-binary-packages-upload-step
       uses: actions/upload-artifact@v4
       with:
         name: ${{ env.PKG_NAME }}_${{ env.PKG_VERSION }}-debian-packages

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -74,21 +74,43 @@ runs:
         echo "::endgroup::"
 
         echo "::group::Prepare source build"
-        echo SOURCE_OUTPUT_DIR="$( mktemp --directory --tmpdir=. )" >> $GITHUB_ENV
+        echo SOURCE_OUTPUT_DIR="$( mktemp --directory --tmpdir="${PWD}" )" >> $GITHUB_ENV
         echo "::endgroup::"
+
     - name: Build source package
-      uses: jtdor/build-deb-action@v1
+      uses: kohlerdominik/docker-run-action@v1.2.0
       with:
-        source-dir: ${{ inputs.source-dir }}
-        artifacts-dir: ${{ env.SOURCE_OUTPUT_DIR }}
-        docker-image: ${{ inputs.docker-image }}
-        buildpackage-opts: --build=source
-        extra-build-deps: ca-certificates git
-        before-build-hook: |
+        image: ${{ inputs.docker-image }}
+        environment: |
+          DEBIAN_FRONTEND=noninteractive
+        volumes: ${{ github.workspace }}:${{ github.workspace }}
+        workdir: ${{ github.workspace }}/${{ inputs.source-dir }}
+        shell: bash
+        run: |
+          echo "::group::Update builder instance"
+          set -eu
+
+          echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90aptyes
+          apt update
+          apt dist-upgrade
+          echo "::endgroup::"
+
+          echo "::group::Install build dependencies"
+          apt build-dep .
+          apt install git ca-certificates
+          echo "::endgroup::"
+
           GITHUB_TOKEN="${{ inputs.token }}"
           if [ -n "${GITHUB_TOKEN}" ]; then
             git config --system url."https://api:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
           fi
+
+          echo "::group::Build debian source package"
+          dpkg-buildpackage -D -S --sanitize-env
+          echo "::endgroup::"
+
+          mv -v ../"${{ env.PKG_NAME }}_"* "${{ env.SOURCE_OUTPUT_DIR }}"
+
     - name: Set up package build
       shell: bash
       run: |

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -107,7 +107,7 @@ runs:
         echo "::group::Extract source package"
         BUILD_INPUT_DIR=$(realpath "${BUILD_INPUT_DIR}")
         cd ${{ env.SOURCE_OUTPUT_DIR }}
-        dpkg-source --extract *.dsc "${BUILD_INPUT_DIR}"
+        dpkg-source --extract ${{ env.PKG_NAME }}_${{ env.PKG_VERSION }}.dsc "${BUILD_INPUT_DIR}"
         cd -
         echo "::endgroup::"
     - name: Build package

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -169,12 +169,23 @@ runs:
           apt dist-upgrade
           echo "::endgroup::"
 
+          echo "::group::Create build user"
+          apt install adduser
+          apt-mark auto adduser
+          adduser --disabled-password --gecos "" builder
+          chown builder:builder .. -R
+          echo "::endgroup::"
+
+          echo "::group::Cleanup unneeded packages"
+          apt autoremove
+          echo "::endgroup::"
+
           echo "::group::Install build dependencies"
           apt build-dep .
           echo "::endgroup::"
 
           echo "::group::Build debian packages"
-          dpkg-buildpackage -D -b --sanitize-env
+          runuser -u builder -- dpkg-buildpackage -D -b --sanitize-env
           echo "::endgroup::"
 
           mv -v ../*"_${{ env.PKG_VERSION }}_"*.deb "${{ env.BUILD_OUTPUT_DIR }}"

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -88,7 +88,8 @@ runs:
 
           echo "::group::Update debian package changelog"
           dch --local "~$(lsb_release -r -s)+git${{ env.VERSION_REF }}" \
-            "Github build. Run id: ${{ github.run_id }}. Run number: ${{ github.run_number }}."
+            "Github build. Run id: ${{ github.run_id }}. Run number: ${{ github.run_number }}." \
+            --distribution "$(lsb_release -c -s)"
 
           dpkg-parsechangelog
           echo "::endgroup::"

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -12,11 +12,16 @@ inputs:
   token:
     required: false
     description: If provided, used for git authentication in the source build
+  extra-source-build-deps:
+    description: A list of extra build dependencies required during source build.
+    required: false
+    # FIXME: this should default to '', but we don't want to break job depending on us for now
+    default: 'ca-certificates git'
 
 
 # The process:
-# 1. We build the source package in a docker container with ca-certificates installed and thus,
-#    a useful internet connection.
+# 1. We build the source package in a docker container. If ca-certificates are
+#    installed via extra-source-build-deps we can have a useful internet connection.
 # 2. We the extract the source package.
 # 3. We build the .deb from the source package, in a container without ca-certificates (unless it
 #    is added as a build dependency), hence without a useful internet connection.
@@ -97,7 +102,11 @@ runs:
 
           echo "::group::Install build dependencies"
           apt build-dep .
-          apt install git ca-certificates
+          if [ -n "${{ inputs.extra-source-build-deps }}" ]; then
+            # Install extra packages for build-deps, to allow downloading vendored sources
+            deps=(${{ inputs.extra-source-build-deps }})
+            apt install ${deps[@]}
+          fi
           echo "::endgroup::"
 
           GITHUB_TOKEN="${{ inputs.token }}"

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -53,9 +53,9 @@ runs:
     - name: Set up source package build
       shell: bash
       run: |
+        echo "::group::Create local version with commit and docker container"
         set -eu
 
-        echo "::group::Create local version with commit and docker container"
         cd '${{ inputs.source-dir }}'
 
         # Short commit to avoid "package-has-long-file-name"
@@ -167,9 +167,9 @@ runs:
     - name: Set up package build
       shell: bash
       run: |
+        echo "::group::Create build input directory"
         set -eu
 
-        echo "::group::Create build input directory"
         # Appending /source because 'dpkg-source --extract' needs the output directory to be non-existent
         BUILD_INPUT_BASEDIR="$( mktemp --directory --tmpdir="${PWD}" )"
         echo BUILD_INPUT_BASEDIR="${BUILD_INPUT_BASEDIR}" >> $GITHUB_ENV

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -175,7 +175,7 @@ runs:
         BUILD_INPUT_DIR="${BUILD_INPUT_BASEDIR}/source"
         echo BUILD_INPUT_DIR="${BUILD_INPUT_DIR}" >> $GITHUB_ENV
         echo "::endgroup::"
-        
+
         echo "::group::Create build output directory"
         echo BUILD_OUTPUT_DIR="$( mktemp --directory --tmpdir="${PWD}" )" >> $GITHUB_ENV
         echo "::endgroup::"

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -51,10 +51,20 @@ runs:
         DEBIAN_FRONTEND=noninteractive sudo apt install -y devscripts
         echo "::endgroup::"
 
-        echo "::group::Append commit SHA to local version"
+        echo "::group::Create local version with commit and docker container"
         cd '${{ inputs.source-dir }}'
-        sanitized_docker=$( echo "${{ inputs.docker-image }}" | sed 's/://' )
-        debchange --local "+${sanitized_docker}+${{ github.sha }}" "Github build. Job id: ${{ github.run_id }}. Attempt: ${{ github.run_number }}."
+
+        # Sanitize the docker name so that it stick to debian policy
+        # https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+        sanitized_docker=$( echo "${{ inputs.docker-image }}" | sed -r 's/[^a-zA-Z0-9.+~]+/+/g' )
+
+        # Short commit to avoid "package-has-long-file-name"
+        commit=$(echo ${{ github.sha }} | cut -c1-8)
+
+        export DEBFULLNAME="GitHub actions runner"
+        export DEBEMAIL="noreply@github.com"
+        debchange --local "~${sanitized_docker}+${commit}" "Github build. Run id: ${{ github.run_id }}. Run number: ${{ github.run_number }}."
+        
         echo "::endgroup::"
 
         echo "::group::Parsing name and version"

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -134,26 +134,51 @@ runs:
 
         echo "::group::Create build input directory"
         # Appending /source because 'dpkg-source --extract' needs the output directory to be non-existent
-        BUILD_INPUT_DIR="$( mktemp --directory --tmpdir='.' )/source"
+        BUILD_INPUT_BASEDIR="$( mktemp --directory --tmpdir="${PWD}" )"
+        echo BUILD_INPUT_BASEDIR="${BUILD_INPUT_BASEDIR}" >> $GITHUB_ENV
+        BUILD_INPUT_DIR="${BUILD_INPUT_BASEDIR}/source"
         echo BUILD_INPUT_DIR="${BUILD_INPUT_DIR}" >> $GITHUB_ENV
         echo "::endgroup::"
         
         echo "::group::Create build output directory"
-        echo BUILD_OUTPUT_DIR="$( mktemp --directory --tmpdir='.' )" >> $GITHUB_ENV
+        echo BUILD_OUTPUT_DIR="$( mktemp --directory --tmpdir="${PWD}" )" >> $GITHUB_ENV
         echo "::endgroup::"
 
         echo "::group::Extract source package"
-        BUILD_INPUT_DIR=$(realpath "${BUILD_INPUT_DIR}")
         cd ${{ env.SOURCE_OUTPUT_DIR }}
         dpkg-source --extract ${{ env.PKG_NAME }}_${{ env.PKG_VERSION }}.dsc "${BUILD_INPUT_DIR}"
-        cd -
         echo "::endgroup::"
-    - name: Build package
-      uses: jtdor/build-deb-action@v1
+
+    - name: Build packages
+      uses: kohlerdominik/docker-run-action@v1.2.0
       with:
-        artifacts-dir: ${{ env.BUILD_OUTPUT_DIR }}
-        source-dir: ${{ env.BUILD_INPUT_DIR }}
-        docker-image: ${{ inputs.docker-image }}
+        image: ${{ inputs.docker-image }}
+        environment: |
+          DEBIAN_FRONTEND=noninteractive
+        workdir: ${{ env.BUILD_INPUT_DIR }}
+        volumes: |
+          ${{ env.BUILD_INPUT_BASEDIR }}:${{ env.BUILD_INPUT_BASEDIR }}
+          ${{ env.BUILD_OUTPUT_DIR }}:${{ env.BUILD_OUTPUT_DIR }}
+        shell: bash
+        run: |
+          echo "::group::Update builder instance"
+          set -eu
+
+          echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90aptyes
+          apt update
+          apt dist-upgrade
+          echo "::endgroup::"
+
+          echo "::group::Install build dependencies"
+          apt build-dep .
+          echo "::endgroup::"
+
+          echo "::group::Build debian packages"
+          dpkg-buildpackage -D -b --sanitize-env
+          echo "::endgroup::"
+
+          mv -v ../*"_${{ env.PKG_VERSION }}_"*.deb "${{ env.BUILD_OUTPUT_DIR }}"
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -63,6 +63,11 @@ runs:
 
         echo DEBFULLNAME="GitHub actions runner" >> $GITHUB_ENV
         echo DEBEMAIL="noreply@github.com" >> $GITHUB_ENV
+
+        if git status --porcelain &>/dev/null; then
+          echo DEBFULLNAME="$(git log -1 --format='%an' HEAD) - GH Action" >> $GITHUB_ENV
+          echo DEBEMAIL="$(git log -1 --format='%ae' HEAD)" >> $GITHUB_ENV
+        fi
         echo "::endgroup::"
 
     - name: Prepare source package

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -119,6 +119,6 @@ runs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.PKG_NAME }}_${{ env.PKG_VERSION }}
+        name: ${{ env.PKG_NAME }}_${{ env.PKG_VERSION }}-debian-packages
         path: ${{ env.BUILD_OUTPUT_DIR }}/
         if-no-files-found: error

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -120,6 +120,13 @@ runs:
 
           mv -v ../"${{ env.PKG_NAME }}_"* "${{ env.SOURCE_OUTPUT_DIR }}"
 
+    - name: Uploading source packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.PKG_NAME }}_${{ env.PKG_VERSION }}-debian-source
+        path: ${{ env.SOURCE_OUTPUT_DIR }}/
+        if-no-files-found: error
+
     - name: Set up package build
       shell: bash
       run: |

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -55,28 +55,50 @@ runs:
       run: |
         set -eu
 
-        echo "::group::Install devscripts"
-        DEBIAN_FRONTEND=noninteractive sudo apt update
-        DEBIAN_FRONTEND=noninteractive sudo apt install -y devscripts
-        echo "::endgroup::"
-
         echo "::group::Create local version with commit and docker container"
         cd '${{ inputs.source-dir }}'
 
-        # Sanitize the docker name so that it stick to debian policy
-        # https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
-        sanitized_docker=$( echo "${{ inputs.docker-image }}" | sed -r 's/[^a-zA-Z0-9.+~]+/+/g' )
-
         # Short commit to avoid "package-has-long-file-name"
-        commit=$(echo ${{ github.sha }} | cut -c1-8)
+        echo VERSION_REF=$(date +'%y%m%d').${{ github.run_number }}.$(echo ${{ github.sha }} | cut -c1-8) >> $GITHUB_ENV
 
-        export DEBFULLNAME="GitHub actions runner"
-        export DEBEMAIL="noreply@github.com"
-        debchange --local "~${sanitized_docker}+${commit}" "Github build. Run id: ${{ github.run_id }}. Run number: ${{ github.run_number }}."
-        
+        echo DEBFULLNAME="GitHub actions runner" >> $GITHUB_ENV
+        echo DEBEMAIL="noreply@github.com" >> $GITHUB_ENV
         echo "::endgroup::"
 
+    - name: Prepare source package
+      uses: kohlerdominik/docker-run-action@v2.0.0
+      with:
+        image: ${{ inputs.docker-image }}
+        environment: |
+          DEBIAN_FRONTEND=noninteractive
+          DEBFULLNAME=${{ env.DEBFULLNAME }}
+          DEBEMAIL=${{ env.DEBEMAIL }}
+        volumes: ${{ github.workspace }}:${{ github.workspace }}
+        workdir: ${{ github.workspace }}/${{ inputs.source-dir }}
+        shell: bash
+        run: |
+          echo "::group::Update builder instance and install dependencies"
+          set -eu
+
+          echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90aptyes
+          apt update
+          apt install devscripts lsb-release
+          echo "::endgroup::"
+
+          echo "::group::Update debian package changelog"
+          dch --local "~$(lsb_release -r -s)+git${{ env.VERSION_REF }}" \
+            "Github build. Run id: ${{ github.run_id }}. Run number: ${{ github.run_number }}."
+
+          dpkg-parsechangelog
+          echo "::endgroup::"
+
+    - name: Parse package source info
+      shell: bash
+      run: |
         echo "::group::Parsing name and version"
+        set -eu
+
+        cd '${{ inputs.source-dir }}'
         echo PKG_NAME="$( dpkg-parsechangelog --show-field source )" >> $GITHUB_ENV
         echo PKG_VERSION="$( dpkg-parsechangelog --show-field version )" >> $GITHUB_ENV
         cd -
@@ -87,7 +109,7 @@ runs:
         echo "::endgroup::"
 
     - name: Build source package
-      uses: kohlerdominik/docker-run-action@v1.2.0
+      uses: kohlerdominik/docker-run-action@v2.0.0
       with:
         image: ${{ inputs.docker-image }}
         environment: |
@@ -113,6 +135,10 @@ runs:
             apt install ${deps[@]}
           fi
           echo "::endgroup::"
+
+          if command -v git &> /dev/null; then
+            git config --system --add safe.directory "${{ github.workspace }}"
+          fi
 
           GITHUB_TOKEN="${{ inputs.token }}"
           if [ -n "${GITHUB_TOKEN}" ]; then
@@ -155,7 +181,7 @@ runs:
         echo "::endgroup::"
 
     - name: Build packages
-      uses: kohlerdominik/docker-run-action@v1.2.0
+      uses: kohlerdominik/docker-run-action@v2.0.0
       with:
         image: ${{ inputs.docker-image }}
         options: --cap-add=NET_ADMIN

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -87,7 +87,7 @@ runs:
           echo "::endgroup::"
 
           echo "::group::Update debian package changelog"
-          dch --local "~$(lsb_release -r -s)+git${{ env.VERSION_REF }}" \
+          dch --local "+git${{ env.VERSION_REF }}~$(lsb_release -r -s)." \
             "Github build. Run id: ${{ github.run_id }}. Run number: ${{ github.run_number }}." \
             --distribution "$(lsb_release -c -s)"
 

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -17,6 +17,10 @@ inputs:
     required: false
     # FIXME: this should default to '', but we don't want to break job depending on us for now
     default: 'ca-certificates git'
+  DEB_BUILD_OPTIONS:
+    required: false
+    default: ''
+    description: The DEB_BUILD_OPTIONS environment variable that is used during builds.
 
 
 # The process:
@@ -88,6 +92,7 @@ runs:
         image: ${{ inputs.docker-image }}
         environment: |
           DEBIAN_FRONTEND=noninteractive
+          DEB_BUILD_OPTIONS=${{ inputs.DEB_BUILD_OPTIONS }}
         volumes: ${{ github.workspace }}:${{ github.workspace }}
         workdir: ${{ github.workspace }}/${{ inputs.source-dir }}
         shell: bash
@@ -156,6 +161,7 @@ runs:
         options: --cap-add=NET_ADMIN
         environment: |
           DEBIAN_FRONTEND=noninteractive
+          DEB_BUILD_OPTIONS=${{ inputs.DEB_BUILD_OPTIONS }}
         workdir: ${{ env.BUILD_INPUT_DIR }}
         volumes: |
           ${{ env.BUILD_INPUT_BASEDIR }}:${{ env.BUILD_INPUT_BASEDIR }}

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -23,8 +23,8 @@ inputs:
 # 1. We build the source package in a docker container. If ca-certificates are
 #    installed via extra-source-build-deps we can have a useful internet connection.
 # 2. We the extract the source package.
-# 3. We build the .deb from the source package, in a container without ca-certificates (unless it
-#    is added as a build dependency), hence without a useful internet connection.
+# 3. We build the .deb from the source package, in a container without internet
+#    kind of internet connection.
 #
 # To help with debugging, here are the processes and the directories they takes place in:
 #
@@ -153,6 +153,7 @@ runs:
       uses: kohlerdominik/docker-run-action@v1.2.0
       with:
         image: ${{ inputs.docker-image }}
+        options: --cap-add=NET_ADMIN
         environment: |
           DEBIAN_FRONTEND=noninteractive
         workdir: ${{ env.BUILD_INPUT_DIR }}
@@ -174,6 +175,13 @@ runs:
           apt-mark auto adduser
           adduser --disabled-password --gecos "" builder
           chown builder:builder .. -R
+          echo "::endgroup::"
+
+          echo "::group::Fully disable internet access for user"
+          apt install iptables
+          apt-mark auto iptables
+          iptables -A OUTPUT -m owner --uid-owner $(id -u builder) -d 127.0.0.1 -j ACCEPT
+          iptables -A OUTPUT -m owner --uid-owner $(id -u builder) -j DROP
           echo "::endgroup::"
 
           echo "::group::Cleanup unneeded packages"

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -17,10 +17,6 @@ inputs:
     required: false
     # FIXME: this should default to '', but we don't want to break job depending on us for now
     default: 'ca-certificates git'
-  DEB_BUILD_OPTIONS:
-    required: false
-    default: ''
-    description: The DEB_BUILD_OPTIONS environment variable that is used during builds.
 
 
 # The process:
@@ -119,7 +115,6 @@ runs:
         image: ${{ inputs.docker-image }}
         environment: |
           DEBIAN_FRONTEND=noninteractive
-          DEB_BUILD_OPTIONS=${{ inputs.DEB_BUILD_OPTIONS }}
         volumes: ${{ github.workspace }}:${{ github.workspace }}
         workdir: ${{ github.workspace }}/${{ inputs.source-dir }}
         shell: bash
@@ -193,7 +188,6 @@ runs:
         options: --cap-add=NET_ADMIN
         environment: |
           DEBIAN_FRONTEND=noninteractive
-          DEB_BUILD_OPTIONS=${{ inputs.DEB_BUILD_OPTIONS }}
         workdir: ${{ env.BUILD_INPUT_DIR }}
         volumes: |
           ${{ env.BUILD_INPUT_BASEDIR }}:${{ env.BUILD_INPUT_BASEDIR }}

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -221,6 +221,10 @@ runs:
           apt autoremove
           echo "::endgroup::"
 
+          echo "::group::Install fakeroot"
+          apt install fakeroot
+          echo "::endgroup::"
+
           echo "::group::Install build dependencies"
           apt build-dep .
           echo "::endgroup::"

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -235,6 +235,14 @@ runs:
 
           mv -v ../*"_${{ env.PKG_VERSION }}_"*.deb "${{ env.BUILD_OUTPUT_DIR }}"
 
+          echo "::group::Show binaries information"
+          for i in "${{ env.BUILD_OUTPUT_DIR }}"/*.deb; do
+            echo "$(basename "$i")"
+            dpkg --info "$i"
+            dpkg --contents "$i"
+          done
+          echo "::endgroup::"
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/gh-actions/go/generate/action.yaml
+++ b/gh-actions/go/generate/action.yaml
@@ -24,6 +24,22 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up jq
+      shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        echo "::group::Download jq"
+        set -eu
+        if [ "${{runner.os}}" = "Windows" ]; then
+          winget.exe install jqlang.jq --accept-source-agreements --accept-package-agreements --silent --verbose || true
+        else
+          SUDO=$(command -v sudo || true)
+          $SUDO apt update
+          $SUDO apt install jq
+        fi
+        echo "::endgroup::"
+        jq --version
     - name: Install tools and dependencies
       id: proto-deps
       working-directory: ${{ inputs.tools-directory }}
@@ -31,7 +47,8 @@ runs:
         echo "::group::Install tools and dependencies"
         set -eu
 
-        tools=$(grep -o '_ ".*"' *.go | cut -d '"' -f 2)
+        tools=$(go mod edit --json | \
+          jq -r '.Require[] | select(.Indirect!=true) | [.Path,.Version] | join("@")')
 
         needsProtoc=false
         for tool in ${tools}; do

--- a/gh-actions/go/generate/action.yaml
+++ b/gh-actions/go/generate/action.yaml
@@ -24,22 +24,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up jq
-      shell: bash
-      env:
-        DEBIAN_FRONTEND: noninteractive
-      run: |
-        echo "::group::Download jq"
-        set -eu
-        if [ "${{runner.os}}" = "Windows" ]; then
-          winget.exe install jqlang.jq --accept-source-agreements --accept-package-agreements --silent --verbose || true
-        else
-          SUDO=$(command -v sudo || true)
-          $SUDO apt update
-          $SUDO apt install jq
-        fi
-        echo "::endgroup::"
-        jq --version
     - name: Install tools and dependencies
       id: proto-deps
       working-directory: ${{ inputs.tools-directory }}
@@ -47,8 +31,7 @@ runs:
         echo "::group::Install tools and dependencies"
         set -eu
 
-        tools=$(go mod edit --json | \
-          jq -r '.Require[] | select(.Indirect!=true) | [.Path,.Version] | join("@")')
+        tools=$(grep -o '_ ".*"' *.go | cut -d '"' -f 2)
 
         needsProtoc=false
         for tool in ${tools}; do


### PR DESCRIPTION
As underlined in https://github.com/ubuntu/authd/pull/130#issuecomment-1963005213 using `jtdor/build-deb-action` for building debian packages has some problems that are yet not clear, and it also does not seem to properly support building non-native packages.

As per this, given that the code needed for handling the build inside a simpler docker container is quite small, I've moved the build to manual handling which allows us some more control over the steps at the cost of being a bit more verbose.

As bonus:
 - We now only build as user (not the sources, since there's no much point)
 - All the network traffic is totally blocked for the builder user (not just HTTPS)
 - `DEB_BUILD_OPTIONS` can be customized for special builds (e.g. `nocheck`)
 - Version uses actual distro version

I've added some commits from #22, but not included the lintian build yet (that I've ready [here](https://github.com/3v1n0/desktop-engineering/commit/1b72205f715fc15abbbeb33708215a6a14be2815)) not to make this PR harder to check, but also because I think those could instead be part of another action to allow more parallelization when used.

By doing this change, not only both test cases pass, but also authd is correctly built: https://github.com/ubuntu/authd/pull/130 (e.g. https://github.com/ubuntu/authd/actions/runs/8044158864)

UDENG-2439