### PR TITLE
feat(ci): track GH action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# See the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  ## We need to list each subdirectories in a separate section:
+  ## https://github.com/dependabot/dependabot-core/issues/6704
+  - package-ecosystem: "github-actions"
+    directory: "/gh-actions/common/build-debian"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(common-ci)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/gh-actions/common/has-diff"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(common-ci)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/gh-actions/common/print-summary"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(common-ci)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/gh-actions/common/validate-pr-title"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(common-ci)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/gh-actions/go/code-sanity"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(go-ci)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/gh-actions/go/generate"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(go-ci)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/gh-actions/rust/code-sanity"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(rust-ci)"


### PR DESCRIPTION
Unfortunately, we need to track each actions file manually as dependabot doesn’t look recursively in directory.

UDENG-2526