### PR TITLE
maint: update golangci-lint action

### DIFF
--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -120,7 +120,7 @@ runs:
     - name: Code formatting, vet, static checker Security…
       if: ${{ always() && steps.golanci-lint.outcome == 'success' }}
       id: golangci-lint-check
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v6
       with:
         version: ${{ steps.tooling-version.outputs.golangci-lint }}
         args: ${{ steps.golanci-lint.outputs.args }}

--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -106,17 +106,6 @@ runs:
         fi
         echo "args=${args}" >> $GITHUB_OUTPUT
 
-    - name: Workaround for golangci-lint bug
-      if: ${{ always() && steps.golanci-lint.outcome == 'success' && runner.os == 'Linux' }}
-      shell: bash
-      # This step is separated from the previous one because we need to be at the repository root
-      run: |
-        # A terrible workaround for https://github.com/golangci/golangci-lint-action/issues/135
-
-        # Avoid using sudo (it is unavailable in docker)
-        sudo --version &> /dev/null && SUDO="sudo" || SUDO=""
-
-        $SUDO chmod -R +w ../../../go/
     - name: Code formatting, vet, static checker Security…
       if: ${{ always() && steps.golanci-lint.outcome == 'success' }}
       id: golangci-lint-check


### PR DESCRIPTION
This update allows to remove an hack that was previously necessary. Also, we need v6 now for GH to accepts the annotations format.

UDENG-4223