### PR TITLE
gh-actions: Add action to install gotestfmt and our wrapper script

### DIFF
--- a/gh-actions/go/gotestfmt/action.yaml
+++ b/gh-actions/go/gotestfmt/action.yaml
@@ -11,6 +11,7 @@ runs:
     - name: Install gotestfmt
       working-directory: ${{ inputs.tools-directory }}
       run: |
+        # Install gotestfmt
         set -eu
         TOOL=github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt
         VERSION=$(go mod edit --json | jq -r ".Require[] | select(.Path==\"${TOOL}\") | .Version" || true)
@@ -24,11 +25,12 @@ runs:
 
     - name: Install gotestfmt wrapper script
       run: |
+        # Install gotestfmt wrapper script
+        set -eu
         # We install the wrapper to a different directory to avoid conflicts
         # with the gotestfmt binary. We also add the directory to the PATH.
         # The wrapper script expects gotestfmt to be in $GOPATH/bin, where
         # go install puts it.
-        set -eu
         DEST=${GITHUB_ACTION_PATH}/bin
         install -D --mode=755 -t "${DEST}" "${GITHUB_ACTION_PATH}/gotestfmt"
         echo "${DEST}" >> "${GITHUB_PATH}"

--- a/gh-actions/go/gotestfmt/action.yaml
+++ b/gh-actions/go/gotestfmt/action.yaml
@@ -2,15 +2,24 @@ name: Install gotestfmt and our wrapper script
 description: Install gotestfmt and our wrapper script which improves the output and copies it to log files
 
 inputs:
-  version:
-    description: The version of gotestfmt to install
-    default: "latest"
+  tools-directory:
+    description: Directory pointing to go.mod file for checking tool versioning. If none is provided, the latest version will be downloaded.
 
 runs:
   using: "composite"
   steps:
     - name: Install gotestfmt
-      run: go install "github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@${{ inputs.version }}"
+      working-directory: ${{ inputs.tools-directory }}
+      run: |
+        set -eu
+        TOOL=github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt
+        VERSION=$(go mod edit --json | jq -r ".Require[] | select(.Path==\"${TOOL}\") | .Version" || true)
+
+        if [ -z "${VERSION}" ]; then
+          VERSION="latest"
+        fi
+
+        go install "${TOOL}@${VERSION}"
       shell: bash
 
     - name: Install gotestfmt wrapper script

--- a/gh-actions/go/gotestfmt/action.yaml
+++ b/gh-actions/go/gotestfmt/action.yaml
@@ -1,11 +1,16 @@
 name: Install gotestfmt and our wrapper script
 description: Install gotestfmt and our wrapper script which improves the output and copies it to log files
 
+inputs:
+  version:
+    description: The version of gotestfmt to install
+    default: "latest"
+
 runs:
   using: "composite"
   steps:
     - name: Install gotestfmt
-      run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+      run: go install "github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@${{ inputs.version }}"
       shell: bash
 
     - name: Install gotestfmt wrapper script

--- a/gh-actions/go/gotestfmt/action.yaml
+++ b/gh-actions/go/gotestfmt/action.yaml
@@ -1,0 +1,21 @@
+name: Install gotestfmt and our wrapper script
+description: Install gotestfmt and our wrapper script which improves the output and copies it to log files
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install gotestfmt
+      run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+      shell: bash
+
+    - name: Install gotestfmt wrapper script
+      run: |
+        # We install the wrapper to a different directory to avoid conflicts
+        # with the gotestfmt binary. We also add the directory to the PATH.
+        # The wrapper script expects gotestfmt to be in $GOPATH/bin, where
+        # go install puts it.
+        set -eu
+        DEST=${GITHUB_ACTION_PATH}/bin
+        install -D --mode=755 -t "${DEST}" "${GITHUB_ACTION_PATH}/gotestfmt"
+        echo "${DEST}" >> "${GITHUB_PATH}"
+      shell: bash

--- a/gh-actions/go/gotestfmt/gotestfmt
+++ b/gh-actions/go/gotestfmt/gotestfmt
@@ -82,4 +82,12 @@ copy_output | \
 # Print the stderr file to stderr
 cat >&2 "${STDERR_FILE}"
 
+# If the exitcode is 0 (i.e. no tests failed), print the logfile to
+# stdout, so that we can see which tests were run. We don't do that
+# if tests failed, so that the failed tests don't get lost in the
+# amount of successful tests.
+if [ "${exitcode:-0}" -eq 0 ]; then
+    cat "${LOGFILE}"
+fi
+
 exit "${exitcode:-0}"

--- a/gh-actions/go/gotestfmt/gotestfmt
+++ b/gh-actions/go/gotestfmt/gotestfmt
@@ -10,7 +10,7 @@ This script is a wrapper around gotestfmt. It expects the output of 'go test -js
 on stdin. The output of failed tests is written to stdout, while the full output
 (including successful tests) is written to a logfile.
 
-The gotestfmt binary is expected to be in GOPATH/bin, or in $HOME/go/bin if GOPATH
+The gotestfmt binary is expected to be in GOPATH/bin, or in HOME/go/bin if GOPATH
 is not set. If your gotestfmt binary is located elsewhere, you can set the GOTESTFMT
 environment variable to the correct path.
 

--- a/gh-actions/go/gotestfmt/gotestfmt
+++ b/gh-actions/go/gotestfmt/gotestfmt
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage(){
+    cat <<EOF
+Usage: $0 [--logfile <logfile>] [-h|--help]
+
+This script is a wrapper around gotestfmt. It expects the output of 'go test -json'
+on stdin. The output of failed tests is written to stdout, while the full output
+(including successful tests) is written to a logfile.
+
+The gotestfmt binary is expected to be in GOPATH/bin, or in $HOME/go/bin if GOPATH
+is not set. If your gotestfmt binary is located elsewhere, you can set the GOTESTFMT
+environment variable to the correct path.
+
+Options:
+  --logfile <logfile>  Logfile to write the full output to. Defaults to a temporary file.
+  -h, --help           Show this help message and exit.
+EOF
+}
+
+# Parse options
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --logfile)
+            LOGFILE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+LOGFILE=${LOGFILE:-$(mktemp -t gotestfmt.XXXXXX.log)}
+echo >&2 "gotestfmt: Logging to ${LOGFILE}"
+STDERR_FILE=${LOGFILE%.log}.stderr
+STDOUT_FILE=${LOGFILE%.log}.stdout
+GOTESTFMT=${GOTESTFMT:-${GOPATH:-$HOME/go}/bin/gotestfmt}
+
+strip_go_downloading_lines() {
+    # Strip "go: downloading" lines which would cause jq (used by
+    # `strip_empty_coverage_lines`) to fail.
+    grep -v '^go: downloading'
+}
+
+strip_empty_coverage_lines() {
+    # This strips empty coverage lines from the output of `go test -cover -json`,
+    # which would otherwise be printed as error messages by gotestfmt.
+    jq -c 'select(.Output != null and (.Output | contains("coverage: 0.0%") | not))'
+}
+
+copy_to_logfile() {
+    # This copies the output of `go test -json` to the logfile, and
+    # * uses gotestfmt to format the output
+    # * unsets $GITHUB_WORKFLOW, so that gotestfmt doesn't print the
+    #   `::group::` and `::endgroup::` GitHub Action workflow commands
+    # * removes ANSI color codes, to make the logfile more readable
+    tee >(GITHUB_WORKFLOW='' "${GOTESTFMT}" -showteststatus | sed 's/\x1b\[[0-9;]*m//g' > "${LOGFILE}")
+}
+
+copy_output() {
+    # Copy all output of `go test -json` unformatted to a file, for debugging purposes.
+    # This is useful if a jq format error occurs, to see the output that caused it.
+    tee "${STDOUT_FILE}"
+}
+
+# Write stderr to a file which can be uploaded as an artifact
+copy_output | \
+    strip_go_downloading_lines | \
+    strip_empty_coverage_lines | \
+    copy_to_logfile | \
+    "${GOTESTFMT}" --hide all <&0 2> "${STDERR_FILE}" || exitcode=$?
+
+# Print the stderr file to stderr
+cat >&2 "${STDERR_FILE}"
+
+exit "${exitcode:-0}"


### PR DESCRIPTION
The output of `go test` is notoriously hard to read, especially when a lot of tests are executed and a lot of output is produced. [gotestfmt](https://github.com/GoTestTools/gotestfmt) can hide the output of successful tests and put the output of failed tests in an expandable group.

This PR adds a custom GitHub Action which installs gotestfmt and a wrapper script which improves the output and copies it to log files, which can then be uploaded as test artifacts.

You can see an example of the produced output when a test fails in [this job](https://github.com/ubuntu/authd-oidc-brokers/actions/runs/11819017382/job/32928619473?pr=220). A link to the artifacts of that job can be found in the ["Upload test artifacts" step](https://github.com/ubuntu/authd-oidc-brokers/actions/runs/11819017382/job/32928619473?pr=220#step:7:22) of that job.