### PR TITLE
fix: correcting key for setting story points

### DIFF
--- a/bin/jira-tools.py
+++ b/bin/jira-tools.py
@@ -216,7 +216,7 @@ class JiraClient:
             }
         }
         if i.story_points is not None:
-            payload["customfield_10024"] = i.story_points
+            payload["fields"]["customfield_10024"] = i.story_points
 
         resp = requests.post(
             f"{JIRA_URL}/rest/api/2/issue",


### PR DESCRIPTION
When I made story points for tickets optional I failed to correctly nest the key under `fields` when setting the custom field outside of the in initial payload creation.