### PR TITLE
fix: Uppercase first letter of issue type.

### DIFF
--- a/bin/jira
+++ b/bin/jira
@@ -137,6 +137,9 @@ function create_issue_in_current_sprint {
     description=${LISTARGS[3]}
   fi
 
+  # Uppercase first letter of issue type else JIRA fails to recognize it
+  issue_type=${issue_type^}
+
   echo "  Project: UDENG"
   echo "  Summary: $summary"
   echo "  Type: $issue_type"


### PR DESCRIPTION
To fix

```
% ./jira new task Integration Test
jq: error (at <stdin>:0): Cannot iterate over null (null)
  Project: UDENG
  Summary: Test
  Type: task
  Component: Integration
  Description:
Enter issue body here...
:: Create a new issue with these details? [y/n]
y

:: Creating issue...
{"errorMessages":["Issue does not exist or you do not have permission to see it."],"errors":{}}:: Issue created and added to active pulse: https://warthogs.atlassian.net/browse/null
```