### PR TITLE
feat(gh-actions/build-debian): Support running a workflow script at build-source phase

### DIFF
--- a/.github/workflows/test-build-deb.yaml
+++ b/.github/workflows/test-build-deb.yaml
@@ -88,6 +88,12 @@ jobs:
           docker-image: ubuntu:devel
           lintian: --fail-on error
           extra-source-build-deps: ''
+          extra-source-build-script: |
+            echo '$HOME' is "${HOME}"
+            echo "::group::Get some system information"
+            uname -a
+            cat /etc/os-release
+            echo "::endgroup::"
 
   lintian-to-md:
     name: Test lintian results parser to markdown

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -17,6 +17,13 @@ inputs:
     required: false
     # FIXME: this should default to '', but we don't want to break job depending on us for now
     default: 'ca-certificates git'
+  extra-source-build-script:
+    description: |
+      A script to run to prepare the source build machine.
+      This happens after the dependencies have been installed, but before
+      running `dpkg-buildpackage -S`.
+    required: false
+    default: ''
   lintian:
     required: false
     description: Arguments to pass to lintian, if any. Set to `skip` to skip the lintian check.
@@ -147,6 +154,15 @@ runs:
           GITHUB_TOKEN="${{ inputs.token }}"
           if [ -n "${GITHUB_TOKEN}" ]; then
             git config --system url."https://api:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+          fi
+
+          if [ -n "${{ inputs.extra-source-build-script != '' && 'true' || '' }}" ]; then
+            echo "::group::Run source build script"
+            (
+              set -eux
+              ${{ inputs.extra-source-build-script }}
+            )
+            echo "::endgroup::"
           fi
 
           echo "::group::Build debian source package"

--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: A list of extra build dependencies required during source build.
     required: false
     # FIXME: this should default to '', but we don't want to break job depending on us for now
-    default: 'ca-certificates git'
+    default: 'ca-certificates'
   extra-source-build-script:
     description: |
       A script to run to prepare the source build machine.
@@ -140,9 +140,17 @@ runs:
 
           echo "::group::Install build dependencies"
           apt build-dep .
+
+          GITHUB_TOKEN="${{ inputs.token }}"
+
           if [ -n "${{ inputs.extra-source-build-deps }}" ]; then
             # Install extra packages for build-deps, to allow downloading vendored sources
             deps=(${{ inputs.extra-source-build-deps }})
+
+            if [ -n "${GITHUB_TOKEN}" ]; then
+              deps+=(git)
+            fi
+
             apt install ${deps[@]}
           fi
           echo "::endgroup::"
@@ -151,7 +159,6 @@ runs:
             git config --system --add safe.directory "${{ github.workspace }}"
           fi
 
-          GITHUB_TOKEN="${{ inputs.token }}"
           if [ -n "${GITHUB_TOKEN}" ]; then
             git config --system url."https://api:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
           fi


### PR DESCRIPTION
When building some packages we may need to prepare the build environment before preparing the source package, for example in some cases we may need to enable git access (to compute the package version or similar) or we may need to install tools that are used during debian source building that are not provided in the archive (such as rust crates, hello cargo-vendor-filterer!!).

So instead of polluting this generic action with package-specific requirements, let's just make it support running a script that can do more advanced configurations in the docker instance that is used only during the source-preparation phase.

Not covering the migration yet (since I'd like to provide some more tools for it), but I think that we should drop the specific-git code from this action too, and move it where it's relevant (in the ubuntu-pro-for-wsl repo as action input script instead).

This is required in order to be able to do a `cargo install --root=/usr cargo-vendor-filterer` to build the source package of rust programs as required by authd in https://github.com/ubuntu/authd/pull/130

UDENG-2343