### PR TITLE
feat(gh-actions): Add an action for checking C format

### DIFF
--- a/gh-actions/C/README.md
+++ b/gh-actions/C/README.md
@@ -1,0 +1,28 @@
+# Check source formatting
+
+This folder contains both a script (`format-source.sh`) and a gh-action
+(`format.yaml`) for checking and fixing the format of the source code,
+both locally during the commit operation and in the CI steps during
+a `git push`.
+
+## Configuring
+
+Just copy the `format.yaml` file to the `.github/workflows/` folder and
+the `format-source.sh` script to the project root folder, and edit the
+script to configure the folders where to search for source code files
+(both .c and .h).
+
+Also, edit the `.git/hooks/pre-commit` script:
+
+    #!/bin/sh
+    ./format-source.sh pre-commit
+
+and give to it execution permissions.
+
+Now, every time a `commit` is done, the source code will be checked and,
+if it doesn't follow the desired format, the commit operation will be
+aborted.
+
+Just executing the `format-source.sh` script from the command line will
+automatically format the source following the style defined in the
+`.clang-format` file (or the `clang-format` defaults if it doesn't exist).

--- a/gh-actions/C/format-source.sh
+++ b/gh-actions/C/format-source.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Configure here all the directories where are source files
+SOURCE_FILES="src/*.[ch] tests/*.[ch]"
+
+if [[ "$1" == "pre-commit" ]]; then
+    echo Checking source style
+    PRE_COMMIT=1
+else
+    PRE_COMMIT=0
+fi
+
+passed=true
+for file in $SOURCE_FILES; do
+    if [ $# -eq 0 ]; then
+        # no parameters? Just apply the changes
+        echo Formating $file
+        clang-format -i $file
+    else
+        # any parameter? check that the formatting is fine
+        clang-format $file > $file.formatted
+        echo Checking $file
+        if [ $PRE_COMMIT -eq 0 ]; then
+            diff $file $file.formatted
+        else
+            diff $file $file.formatted > /dev/null
+        fi
+        if [ $? != 0 ]; then
+            passed=false
+        fi
+        rm $file.formatted
+    fi
+done
+if [ $passed = false ]; then
+    echo Failed to pass clang-format check
+    exit 1
+fi

--- a/gh-actions/C/format.yaml
+++ b/gh-actions/C/format.yaml
@@ -1,0 +1,18 @@
+name: Formatting
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Verify formatting
+        run: |
+          ./format-source.sh check


### PR DESCRIPTION
This action and script allows to automatically check the format style in a C/C++ project, using clang-format. It also can be configured as a GIT hook, to also check it automatically before a commit.