### PR TITLE
fix(gotestfmt): Fix incorrect gotestfmt output

### DIFF
--- a/gh-actions/go/gotestfmt/action.yaml
+++ b/gh-actions/go/gotestfmt/action.yaml
@@ -13,7 +13,7 @@ runs:
       run: |
         # Install gotestfmt
         set -eu
-        TOOL=github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt
+        TOOL=github.com/ubuntu/gotestfmt/v2/cmd/gotestfmt
         VERSION=$(go mod edit --json | jq -r ".Require[] | select(.Path==\"${TOOL}\") | .Version" || true)
 
         if [ -z "${VERSION}" ]; then


### PR DESCRIPTION
Use our fork until https://github.com/GoTestTools/gotestfmt/pull/62 has been merged by upstream.

UDENG-5451