### PR TITLE
feat(gh-actions): Add macOS compatibility for go code-sanity and gotestfmt

### DIFF
--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -31,6 +31,8 @@ runs:
         echo "::group::Download jq"
         if [ "${{runner.os}}" = "Windows" ]; then
           winget.exe install jqlang.jq --accept-source-agreements --accept-package-agreements --silent --verbose || true
+        elif [ "${{runner.os}}" = "macOS" ]; then
+          brew install jq
         else
           sudo --version &> /dev/null && SUDO="sudo" || SUDO=""
           DEBIAN_FRONTEND=noninteractive $SUDO apt update

--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -10,7 +10,7 @@ inputs:
   go-tags:
     description: A comma separate list of go tags to consider when linting, building and checking for vulnerabilities.
   tools-directory:
-    description: Directory pointing to go.mod file for checking tool versionning. If none is provided, it will download latest.
+    description: Directory pointing to go.mod file for checking tool versioning. If none is provided, it will download latest.
   golangci-lint-configfile:
     description: Which config file to check for golangci-lint. If not set, it will look for .golangci-lint in your project, or default to desktop team defaults.
   generate-diff-paths-to-ignore:

--- a/gh-actions/go/gotestfmt/action.yaml
+++ b/gh-actions/go/gotestfmt/action.yaml
@@ -32,6 +32,7 @@ runs:
         # The wrapper script expects gotestfmt to be in $GOPATH/bin, where
         # go install puts it.
         DEST=${GITHUB_ACTION_PATH}/bin
-        install -D --mode=755 -t "${DEST}" "${GITHUB_ACTION_PATH}/gotestfmt"
+        mkdir -p "${DEST}"
+        install -m 755 "${GITHUB_ACTION_PATH}/gotestfmt" "${DEST}"
         echo "${DEST}" >> "${GITHUB_PATH}"
       shell: bash


### PR DESCRIPTION
Updates to add macOS compatibility for go code-sanity and gotestfmt

- Use brew to install jq in code-sanity
- Remove and replace unsupported flags in the install command for gotestfmt
  - Use mkdir instead of -D
  - Remove -t
  - Use -m instead of --mode
  
Minor spelling fix

---
UDENG-5777