### PR TITLE
maint(gh-actions/run-autopkgtests): Use main branch for setup-lxd

### DIFF
--- a/gh-actions/common/run-autopkgtest/action.yml
+++ b/gh-actions/common/run-autopkgtest/action.yml
@@ -77,7 +77,7 @@ runs:
         echo "::endgroup::"
 
     - name: Setup LXD
-      uses: canonical/setup-lxd@v0.1.2
+      uses: canonical/setup-lxd@main
       with:
         channel: latest/stable
 


### PR DESCRIPTION
It contains the fix to speedup the image creation, and we can trust that main will be well managed.

If not we can always go back to a version we know it works.