### PR TITLE
maint(gh-actions): Update CLA check to v2

### DIFF
--- a/project-repo/templates/common/.github/workflows/cla-check.yaml
+++ b/project-repo/templates/common/.github/workflows/cla-check.yaml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1
+        uses: canonical/has-signed-canonical-cla@v2
         with:
           accept-existing-contributors: true


### PR DESCRIPTION
Following a recent notification in discourse.canonical.com, the github workflow must be updated to V2 before the end of March.

https://discourse.canonical.com/t/new-contributor-license-agreement-cla-service/5247

This PR does that.