### PR TITLE
gh-actions/build-debian: Quote the deb variables passed to the runner

### DIFF
--- a/gh-actions/common/build-debian/action.yml
+++ b/gh-actions/common/build-debian/action.yml
@@ -152,8 +152,8 @@ runs:
           TERM=dumb
           DEBIAN_FRONTEND=noninteractive
           DEBCONF_NONINTERACTIVE_SEEN=true
-          DEBFULLNAME=${{ env.DEBFULLNAME }}
-          DEBEMAIL=${{ env.DEBEMAIL }}
+          DEBFULLNAME="${{ env.DEBFULLNAME }}"
+          DEBEMAIL="${{ env.DEBEMAIL }}"
         volumes: |
           ${{ env.GITHUB_ACTION_PATH }}:${{ env.GITHUB_ACTION_PATH }}
           ${{ github.workspace }}:${{ github.workspace }}


### PR DESCRIPTION
The DEBFULLNAME may contain spaces, and we should ensure that they are preserved.