### PR TITLE
feat(gh-actions): add common OSV scanner action

### DIFF
--- a/gh-actions/common/osv-scanner/action.yaml
+++ b/gh-actions/common/osv-scanner/action.yaml
@@ -1,0 +1,20 @@
+name: OSV-Scanner
+description: Run osv-scanner-action recursively in the current directory.
+
+runs:
+  using: composite
+  steps:
+    - name: Scan on push
+      if: ${{ github.event_name == 'push' }}
+      uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@f8115f2f28022984d4e8070d2f0f85abcf6f3458" # v1.9.2
+      with:
+        scan-args: |-
+          -r
+          ./
+    - name: Scan on PR
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@f8115f2f28022984d4e8070d2f0f85abcf6f3458" # v1.9.2
+      with:
+        scan-args: |-
+          -r
+          ./


### PR DESCRIPTION
Adds a GitHub action that runs [osv-scanner](https://google.github.io/osv-scanner/) recursively in the current directory.
We've been testing this in a few repositories this week, including https://github.com/canonical/ubuntu-desktop-provision/. Adding this to our common actions here would simplify maintenance.
So far the action uses the default options of the `osv-scanner-action` and doesn't expose any parameters. I'd be open to adding some if further configuration is needed - e.g. by default the action returns with an error status if a vulnerability is found, which might not always be desirable (the GitHub security tab complains about a configuration error in this case). It'd also be possible to run the action only for a specific set of directories or lock files if we added a parameter for that.