### PR TITLE
fix(rust/code-sanity): Fix "rustfmt-check" step

### DIFF
--- a/gh-actions/rust/code-sanity/action.yaml
+++ b/gh-actions/rust/code-sanity/action.yaml
@@ -27,6 +27,7 @@ runs:
       uses: actions-rs/cargo@v1
       with:
         command: fmt
+        args: --check
     - name: Check code format with clippy
       id: clippy-check
       uses: actions-rs/clippy-check@v1


### PR DESCRIPTION
The step succeeded even if the Rust code is not formatted correctly. That's because running `cargo fmt` formats the code and exits with 0. We want `cargo fmt --check` instead, which doesn't actually format the code but checks if it needs formatting, and exits with 1.