### PR TITLE
fix(gh-actions/run-autopkgtests): Install dnsmasq-base

### DIFF
--- a/gh-actions/common/run-autopkgtest/action.yml
+++ b/gh-actions/common/run-autopkgtest/action.yml
@@ -126,7 +126,7 @@ runs:
         set -eu
 
         sudo apt update
-        sudo apt install -y autopkgtest
+        sudo apt install -y autopkgtest dnsmasq-base
 
         echo "::endgroup::"
 


### PR DESCRIPTION
This seems to be now a required component by autopkgtest-build-lxd

See: https://github.com/canonical/setup-lxd/issues/31