### PR TITLE
fix: GH perms action run steps missing shell

### DIFF
--- a/gh-actions/common/gh-perms/action.yaml
+++ b/gh-actions/common/gh-perms/action.yaml
@@ -19,6 +19,7 @@ runs:
       id: check_push
       if: ${{ inputs.fail-for-push != 'false' }}
       continue-on-error: true
+      shell: bash
       run: |
         set -eu
         git config user.name github-actions[bot]
@@ -32,8 +33,9 @@ runs:
       if: ${{ inputs.fail-for-pr != 'false' }}
       id: check_pr
       continue-on-error: true
+      shell: bash
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ inputs.token }}
       run: |
         set -eu
         if [ `gh pr comment -b "You should restrict the github token permissions of the ${{ github.job }} job (ideally to none - `permissions: {}`)" ${{ github.event.pull_request.number }}`]; then


### PR DESCRIPTION
Shell is required in composite actions.
Also the token in an input.

Otherwise
<img width="1427" height="480" alt="image" src="https://github.com/user-attachments/assets/ec3fda85-fad5-46dc-ab35-154413549070" />

🙈 