### PR TITLE
feat(gotestfmt): Divert "build-output" actions

### DIFF
--- a/gh-actions/go/gotestfmt/gotestfmt
+++ b/gh-actions/go/gotestfmt/gotestfmt
@@ -62,6 +62,17 @@ strip_empty_coverage_lines() {
     jq -c 'select(.Output != null and (.Output | contains("coverage: 0.0%") | not))'
 }
 
+divert_build_output_action_lines() {
+    # This diverts lines with the Action "build-output" from the output of `go test -json`
+    # to stderr in case the lines are useful for debugging reasons.
+    # These lines would otherwise cause gotestfmt to panic as it does not know how to handle them.
+    # This kind of output often occurs with linker warnings from the underlying toolchain when using CGo.
+    # They can be suppressed with `CGO_LDFLAGS="-w"`, but figuring that out in the first place
+    # is not always intuitive. See https://github.com/golang/go/issues/61229 for an example of what causes this.
+    tee >(jq -r 'select(.Action == "build-output") | "WARNING: Build output action filtered out -> \(. | tostring)"' >&2) \
+        | jq -c 'select(.Action != "build-output")'
+}
+
 copy_to_logfile() {
     # This copies the output of `go test -json` to the logfile, and
     # * uses gotestfmt to format the output
@@ -81,6 +92,7 @@ copy_output() {
 copy_output | \
     strip_go_downloading_lines | \
     strip_empty_coverage_lines | \
+    divert_build_output_action_lines | \
     tee "${CLEANED_STDOUT_FILE}" | \
     copy_to_logfile | \
     "${GOTESTFMT}" --hide all <&0 2> "${STDERR_FILE}" || exitcode=$?


### PR DESCRIPTION
Currently, `gotestfmt` does not know how to handle outputs from `go test` where the `Action` field is "build-outputs". If it receives a line of this type, then it will panic and print out a byte-encoded string representation of that input's `Output` field.

From what I've seen, this kind of output usually occurs due to a warning output from an underlying toolchain like GCC when using CGo. They can be suppressed with `CGO_LDFLAGS="-w"` but this resolution isn't always intuitive due to how the issue manifests itself. Additionally, these warnings may be genuinely useful.

This PR diverts lines where the `Action` field is "build-outputs", wrapping the line with some additional context and sending it to stderr instead of allowing it to be passed forwards to `gotestfmt` which would in turn panic.

For an example of these changes in use, see this workflow run (ignore the one failure, GitHub's API was degraded at the time): https://github.com/ubuntu/ubuntu-insights/actions/runs/17282035065/job/49052211644?pr=231