### PR TITLE
fix(go/code-sanity): Remove macOS jq installation step

### DIFF
--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -4,7 +4,7 @@ description: Checks code against of our desktop Go code quality and process stan
 inputs:
   working-directory:
     description: Directory were to run the action. All other paths are relative to this one.
-    default: '.'
+    default: "."
   go-build-script:
     description: For more complex build steps, pass the script directly to it (executed through bash). go-tags is then ignored for building.
   go-tags:
@@ -33,8 +33,9 @@ runs:
         echo "::group::Download jq"
         if [ "${{runner.os}}" = "Windows" ]; then
           winget.exe install jqlang.jq --accept-source-agreements --accept-package-agreements --silent --verbose || true
-        elif [ "${{runner.os}}" = "macOS" ]; then
-          brew install jq
+        elif [ "${{ runner.os }}" = "macOS" ]; then
+          # No setup needed for macOS
+          :
         else
           sudo --version &> /dev/null && SUDO="sudo" || SUDO=""
           DEBIAN_FRONTEND=noninteractive $SUDO apt update


### PR DESCRIPTION
Turns out `jq` is included in the GitHub runner images already, so this step isn't needed and, in fact, results in the warning annotation: `jq 1.8.1 is already installed and up-to-date. To reinstall 1.8.1, run: brew reinstall jq`

I wanted to keep the default as Linux, so instead I just made the macOS branch do nothing.

See this run for an example of these changes in use; note the lack of warning annotations now: https://github.com/ubuntu/ubuntu-insights/actions/runs/17302233750?pr=231