### PR TITLE
feat(gh-actions): go/code-sanity: Support input govulncheck-patterns

### DIFF
--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -13,6 +13,9 @@ inputs:
     description: Directory pointing to go.mod file for checking tool versioning. If none is provided, it will download latest.
   golangci-lint-configfile:
     description: Which config file to check for golangci-lint. If not set, it will look for .golangci-lint in your project, or default to desktop team defaults.
+  govulncheck-patterns:
+    description: A space separated list of patterns to consider when checking for vulnerabilities with govulncheck.
+    default: './...'
   generate-diff-paths-to-ignore:
     description: Files and paths to ignore when checking if generated files changed. This is passed to git update-index.
     default: po/* docs/**/*.md README.md
@@ -197,7 +200,7 @@ runs:
           tags="-tags=${tags}"
         fi
 
-        govulncheck -test ${tags} ./...
+        govulncheck -test ${tags} ${{ inputs.govulncheck-patterns }}
       shell: bash
 
     - name: Compute title of summary


### PR DESCRIPTION
I have a case where I need to exclude a package from govulncheck, because that package requires Go 1.25 but the latest govulncheck version only supports Go 1.24, so it fails with:

```
authd/internal/testlog/testlog_go125.go:3:9: file requires newer Go version go1.25 (application built with go1.24)
```

