### PR TITLE
maint: Replace unmaintained actions-rs GitHub Actions

### DIFF
--- a/gh-actions/rust/code-sanity/action.yaml
+++ b/gh-actions/rust/code-sanity/action.yaml
@@ -9,36 +9,27 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions-rs/toolchain@v1
-      id: toolchain
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt, clippy
+    - name: Install latest Rust version
+      shell: bash
+      run: rustup update stable
     - name: Build crate
       id: build-check
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --all-features
+      shell: bash
+      run: cargo build --all-features
     - name: Check code format with rustfmt
       id: rustfmt-check
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --check
+      shell: bash
+      run: cargo fmt --check
     - name: Check code format with clippy
       id: clippy-check
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ inputs.token }}
-        args: --all-features
+      shell: bash
+      run: cargo clippy --all-features
     - name: Check for vulnerabilities with cargo-audit
       id: cargo-audit-check
-      uses: actions-rs/audit-check@v1
-      with:
-        token: ${{ inputs.token }}
+      shell: bash
+      run: |
+        cargo install cargo-audit
+        cargo audit
     - name: Compute title of summary
       if: ${{ always() && steps.toolchain.outcome == 'success' }}
       id: compute-summary-title


### PR DESCRIPTION
The actions-rs GitHub Actions were archived in Oct 2023.

We don't need a GitHub Action anymore to install Rust, because we can just use rustup for that, which is pre-installed on the GitHub runner images.

UDENG-7853