### PR TITLE
feat: Add GitHub Action common/dpkg-exclude-locales-and-manpages

### DIFF
--- a/gh-actions/common/dpkg-exclude-locales-and-manpages/action.yml
+++ b/gh-actions/common/dpkg-exclude-locales-and-manpages/action.yml
@@ -1,0 +1,16 @@
+name: Exclude locales and manpages from dpkg
+description: Configures dpkg to exclude locales and manpages from installed packages, speeding up package installation.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Exclude locales and manpages from dpkg
+      id: exclude-locales-and-manpages
+      shell: bash
+      run: |
+        cat <<EOF | sudo tee /etc/dpkg/dpkg.cfg.d/01-exclude-locales-and-manpages
+        path-exclude=/usr/share/locale/*
+        path-exclude=/usr/share/man/*
+        path-exclude=/usr/share/doc/*
+        path-exclude=/usr/share/info/*
+        EOF

--- a/gh-actions/common/dpkg-install-speedup/action.yml
+++ b/gh-actions/common/dpkg-install-speedup/action.yml
@@ -1,4 +1,4 @@
-name: Exclude locales and manpages from dpkg
+name: Speed up dpkg package installation
 description: Configures dpkg to exclude locales and manpages from installed packages, speeding up package installation.
 
 runs:


### PR DESCRIPTION
This GitHub Action configures dpkg to exclude locales and manpages from installed packages, speeding up package installation. We should use it in all jobs which use APT to install packages, because it can significantly speed up the installation time. Avoiding the man-db triggers alone can reduce the installation time by up to two minutes.

UDENG-7865