### PR TITLE
 Fix missing export of SOURCE_PATHS in format-source.sh invocation

### DIFF
--- a/gh-actions/C/format-source/action.yaml
+++ b/gh-actions/C/format-source/action.yaml
@@ -13,5 +13,4 @@ runs:
     - name: Verify formatting
       shell: bash -eu
       run: |
-        SOURCE_PATHS="${{ inputs.sourcePaths }}"
-        ./format-source.sh check
+        SOURCE_PATHS="${{ inputs.sourcePaths }}" ./format-source.sh check

--- a/gh-actions/C/format-source/format-source.sh
+++ b/gh-actions/C/format-source/format-source.sh
@@ -42,7 +42,7 @@ check_source_file() {
 RESULT=""
 
 if [ -n "${SOURCE_PATHS}" ]; then
-# if SOURCE_PATHS is defined, search only in the specified paths
+    # if SOURCE_PATHS is defined, search only in the specified paths
     for source_path in ${SOURCE_PATHS}; do
         source_path=$(realpath -- "$source_path")
         RESULT=${RESULT}$(find "$source_path" -name '*.c' -or -name '*.h' | while read file; do
@@ -50,15 +50,14 @@ if [ -n "${SOURCE_PATHS}" ]; then
         done)
     done
 else
-
-# a trick to ensure that names/folders with blank spaces do work as expected
-# also, since find and while read... are executed in a subshell, they can't
-# modify any variable outside. That's why we capture the output in $RESULT
-# and compare it with an empty string.
-# Of course, for this to work, it is mandatory to send any visible message to
-# STDERR. That's why the check_source_file() function has so many >&2: those
-# are commands whose output we want in the screen. This trick is needed because
-# there seems to not be an easy way of storing STDERR instead of SDTOUT
+    # a trick to ensure that names/folders with blank spaces do work as expected
+    # also, since find and while read... are executed in a subshell, they can't
+    # modify any variable outside. That's why we capture the output in $RESULT
+    # and compare it with an empty string.
+    # Of course, for this to work, it is mandatory to send any visible message to
+    # STDERR. That's why the check_source_file() function has so many >&2: those
+    # are commands whose output we want in the screen. This trick is needed because
+    # there seems to not be an easy way of storing STDERR instead of SDTOUT
     RESULT=${RESULT}$(find -name '*.c' -or -name '*.h' | while read file; do
         check_source_file "$file"
     done)


### PR DESCRIPTION
The `SOURCE_PATHS` variable was previously assigned in one line and then `./format-source.sh` was invoked on the next.  

This defined `SOURCE_PATHS` only as a shell variable, which is visible within the current shell but not automatically inherited by child processes. 

As a result, `format-source.sh` ran without the variable set, causing it to ignore the intended source paths.  This change fixes the issue by passing `SOURCE_PATHS` as part of the environment for the `format-source.sh` command. 