### PR TITLE
ci: Avoid installing locales and man pages

### DIFF
--- a/.github/workflows/test-build-deb.yaml
+++ b/.github/workflows/test-build-deb.yaml
@@ -28,6 +28,7 @@ jobs:
       ubuntu-image: ${{ env.UBUNTU_IMAGE }}
 
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
         run: |
           # Install dependencies
@@ -104,6 +105,7 @@ jobs:
       run-id: ${{ github.run_id }}
 
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
         run: |
           # Install dependencies
@@ -199,6 +201,7 @@ jobs:
       image: ubuntu:rolling
 
     steps:
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
         env:
           DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
Speed up CI jobs by avoiding installation of locales and man pages.

The major performance gain that can be expected is that it makes the "Processing triggers for man-db" step a no-op. That step can otherwise take more than a minute, for example in [this recent run](https://github.com/canonical/desktop-engineering/actions/runs/17556934441/job/49863373181#step:2:1112) it took 1m 22s:

<img width="687" height="38" alt="image" src="https://github.com/user-attachments/assets/c7634687-262e-4068-9f48-210b549bb8b3" />


UDENG-7865