### PR TITLE
fix(go/code-sanity): correct path passed to govulncheck

### DIFF
--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -183,7 +183,7 @@ runs:
           tags="-tags=${tags}"
         fi
 
-        govulncheck -test ${tags} ./..
+        govulncheck -test ${tags} ./...
 
     - name: Compute title of summary
       if: ${{ always() }}


### PR DESCRIPTION
This PR corrects the path passed to `govulncheck` from `./..` to `./...`