### PR TITLE
fix: Install govulncheck with the correct Go toolchain version

### DIFF
--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -162,12 +162,12 @@ runs:
     - name: Install govulncheck
       if: ${{ always() && steps.tooling-version.outcome == 'success' }}
       id: install-govulncheck
-      working-directory: ${{ runner.temp }}
       shell: bash --noprofile --norc -euo pipefail {0}
       run: |
         # Install govulncheck
         echo "::group::Install govulncheck"
-        go install golang.org/x/vuln/cmd/govulncheck@${{ steps.tooling-version.outputs.vulncheck }}
+        GOTOOLCHAIN=$(go mod edit -json "${{ inputs.tools-directory }}/go.mod" | jq -r '.Toolchain') \
+          go install golang.org/x/vuln/cmd/govulncheck@${{ steps.tooling-version.outputs.vulncheck }}
         echo "::endgroup::"
 
     - name: Known vulnerabilities check


### PR DESCRIPTION
Unless `GOTOOLCHAIN` is specified, the Go version used by `go install` to build the binary is determined by:
1. The `toolchain` directive in the `go.mod` of the module being installed
2. If there is no `toolchain` directive in the `go.mod` of the module being installed, the system's Go is used (the one in PATH).

We specify the Go version that should be used for tools like govulncheck in `tools/go.mod`. So we need to point `GOTOOLCHAIN` to that to actually use that Go version when building govulncheck.

This avoids errors like:

    Error: /home/runner/go/pkg/mod/golang.org/x/sys@v0.35.0/unix/vgetrandom_linux.go:7:9: file requires newer Go version go1.24 (application built with go1.23)

which occur when govulncheck is built with an older Go version than the required version of the module that it should check.

UDENG-8058