### PR TITLE
fix: Fix go/code-sanity failing if no toolchain directive in tools/go.mod

### DIFF
--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -166,7 +166,11 @@ runs:
       run: |
         # Install govulncheck
         echo "::group::Install govulncheck"
-        GOTOOLCHAIN=$(go mod edit -json "${{ inputs.tools-directory }}/go.mod" | jq -r '.Toolchain') \
+        GOTOOLCHAIN=$(go mod edit -json "${{ inputs.tools-directory }}/go.mod" | jq -r '.Toolchain')
+        if [ "${GOTOOLCHAIN}" == "null" ]; then
+          GOTOOLCHAIN="go$(go mod edit -json "${{ inputs.tools-directory }}/go.mod" | jq -r '.Go')"
+        fi
+        GOTOOLCHAIN=${GOTOOLCHAIN} \
           go install golang.org/x/vuln/cmd/govulncheck@${{ steps.tooling-version.outputs.vulncheck }}
         echo "::endgroup::"
 


### PR DESCRIPTION
The `toolchain` directive in a `go.mod` is optional, but commit 8a48366f25234b5c223db6aac399ec660c4ea8c7 caused the installation of govulncheck to fail with `go: invalid GOTOOLCHAIN "null"` if the directive is missing.

Let's fall back to the Go version specified by the `go` directive in case the `toolchain` directive is missing.