### PR TITLE
feat: Support using go tool directive for protoc deps

### DIFF
--- a/gh-actions/go/generate/action.yaml
+++ b/gh-actions/go/generate/action.yaml
@@ -27,29 +27,15 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Install tools and dependencies
-      id: proto-deps
-      working-directory: ${{ inputs.tools-directory }}
+    - name: Install protoc if needed
       shell: bash --noprofile --norc -euo pipefail {0}
       run: |
-        # Install tools and dependencies"
-        echo "::group::Install tools and dependencies"
+        # Check if protoc is needed
+        if ! go -C "${{ inputs.tools-directory }}" tool | grep -q protoc-gen-go; then
+          # protoc-gen-go is not added as a tool in tools/go.mod, so protoc should not be needed
+          exit
+        fi
 
-        tools=$(grep -os '_ ".*"' *.go | cut -d '"' -f 2 || true)
-
-        needsProtoc=false
-        for tool in ${tools}; do
-          if [[ "${tool}" == *protoc* ]]; then
-            echo "needs-protoc=true" >> $GITHUB_OUTPUT
-          fi
-          go install ${tool}
-        done
-        echo "::endgroup::"
-
-    - name: Install latest protoc
-      if: ${{ steps.proto-deps.outputs.needs-protoc == 'true' }}
-      shell: bash --noprofile --norc -euo pipefail {0}
-      run: |
         # Install latest protoc
         echo "::group::Install latest protoc"
 


### PR DESCRIPTION
* Use `go tool` to check if protoc should be installed.
* Drop support for installing tools from `tools/*.go` files - the only reason we kept it after #89 was to avoid breaking protoc.