### PR TITLE
deps(actions): bump osv-scanner-actions to v2.3.8

### DIFF
--- a/gh-actions/common/osv-scanner/action.yaml
+++ b/gh-actions/common/osv-scanner/action.yaml
@@ -6,14 +6,14 @@ runs:
   steps:
     - name: Scan on push
       if: ${{ github.event_name == 'push' }}
-      uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@a30b4c310bacb7c0635e316e0720e23f0b791cf8" # v1.9.2
+      uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8"
       with:
         scan-args: |-
           -r
           ./
     - name: Scan on PR
       if: ${{ github.event_name == 'pull_request' }}
-      uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@a30b4c310bacb7c0635e316e0720e23f0b791cf8" # v1.9.2
+      uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.8"
       with:
         scan-args: |-
           -r


### PR DESCRIPTION
This uses a tag instead of the commit hash. While it's good practice to pin GitHub Actions to commit hashes instead of tags, it's not working well with dependabot. When pinned to a commit hash, dependabot will update it whenever a new commit is pushed to the GitHub Action's default branch, which results in a lot of update PRs.

Since we're also using tags for the other GitHub Actions, and there is no reason to particularly distrust the osv-scanner GitHub Action, let's switch to using tags to avoid unnecessary dependabot PRs.