### PR TITLE
fix: Check GOTOOLCHAIN before attempting to override it

### DIFF
--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -187,12 +187,17 @@ runs:
       run: |
         # Install govulncheck
         echo "::group::Install govulncheck"
-        GOTOOLCHAIN=$(go mod edit -json "${{ inputs.tools-directory }}/go.mod" | jq -r '.Toolchain')
-        if [ "${GOTOOLCHAIN}" == "null" ]; then
-          GOTOOLCHAIN="go$(go mod edit -json "${{ inputs.tools-directory }}/go.mod" | jq -r '.Go')"
-        fi
-        GOTOOLCHAIN=${GOTOOLCHAIN} \
+        if [ -n "${GOTOOLCHAIN}" ]; then
+          echo "Using predefined Go toolchain version ${GOTOOLCHAIN} to install govulncheck"
           go install golang.org/x/vuln/cmd/govulncheck@${{ steps.tooling-version.outputs.vulncheck }}
+        else
+          TOOLCHAIN=$(go mod edit -json "${{ inputs.tools-directory }}/go.mod" | jq -r '.Toolchain')
+          if [ "${TOOLCHAIN}" == "null" ]; then
+            TOOLCHAIN="go$(go mod edit -json "${{ inputs.tools-directory }}/go.mod" | jq -r '.Go')"
+          fi
+          GOTOOLCHAIN=${TOOLCHAIN} \
+            go install golang.org/x/vuln/cmd/govulncheck@${{ steps.tooling-version.outputs.vulncheck }}
+        fi
         echo "::endgroup::"
 
     - name: Known vulnerabilities check

--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: For more complex build steps, pass the script directly to it (executed through bash). go-tags is then ignored for building.
   go-tags:
     description: A comma separate list of go tags to consider when linting, building and checking for vulnerabilities.
+  go-version-file:
+    description: A module or workspace file to check for the Go toolchain version to use. If not provided, it will look for a go.mod file in the working directory.
+    required: false
+    default: ""
   tools-directory:
     description: Directory pointing to go.mod file for checking tool versioning. If none is provided, it will download latest.
   golangci-lint-configfile:
@@ -27,7 +31,7 @@ runs:
   steps:
     - uses: actions/setup-go@v6
       with:
-        go-version-file: ${{ inputs.working-directory }}/go.mod
+        go-version-file: ${{ inputs.go-version-file || format('{0}/go.mod', inputs.working-directory) }}
         check-latest: true
         cache: false
     - name: Install jq

--- a/gh-actions/go/code-sanity/action.yaml
+++ b/gh-actions/go/code-sanity/action.yaml
@@ -191,17 +191,15 @@ runs:
       run: |
         # Install govulncheck
         echo "::group::Install govulncheck"
-        if [ -n "${GOTOOLCHAIN}" ]; then
-          echo "Using predefined Go toolchain version ${GOTOOLCHAIN} to install govulncheck"
-          go install golang.org/x/vuln/cmd/govulncheck@${{ steps.tooling-version.outputs.vulncheck }}
-        else
+        if [ -z "${GOTOOLCHAIN}" ]; then
           TOOLCHAIN=$(go mod edit -json "${{ inputs.tools-directory }}/go.mod" | jq -r '.Toolchain')
           if [ "${TOOLCHAIN}" == "null" ]; then
             TOOLCHAIN="go$(go mod edit -json "${{ inputs.tools-directory }}/go.mod" | jq -r '.Go')"
           fi
-          GOTOOLCHAIN=${TOOLCHAIN} \
-            go install golang.org/x/vuln/cmd/govulncheck@${{ steps.tooling-version.outputs.vulncheck }}
+          export GOTOOLCHAIN="${TOOLCHAIN}"
         fi
+        echo "Using Go toolchain version \"${GOTOOLCHAIN}\" to install govulncheck"
+        go install golang.org/x/vuln/cmd/govulncheck@${{ steps.tooling-version.outputs.vulncheck }}
         echo "::endgroup::"
 
     - name: Known vulnerabilities check


### PR DESCRIPTION
When we moved the v2 tag yesterday we broke CI for projects based on workspaces (at least two I observed: ubuntu-pro-for-wsl and ubuntu-insights). 

```
Run # Install govulncheck
  # Install govulncheck
  echo "::group::Install govulncheck"
  GOTOOLCHAIN=$(go mod edit -json "/home/runner/work/ubuntu-pro-for-wsl/ubuntu-pro-for-wsl/tools/go.mod" | jq -r '.Toolchain')
  if [ "${GOTOOLCHAIN}" == "null" ]; then
    GOTOOLCHAIN="go$(go mod edit -json "/home/runner/work/ubuntu-pro-for-wsl/ubuntu-pro-for-wsl/tools/go.mod" | jq -r '.Go')"
  fi
  GOTOOLCHAIN=${GOTOOLCHAIN} \
    go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
  echo "::endgroup::"
  shell: /usr/bin/bash --noprofile --norc -euo pipefail {0}
  env:
    FLUTTER_ROOT: /opt/hostedtoolcache/flutter/stable-3.41.9-x64/flutter
    PUB_CACHE: /home/runner/.pub-cache
    GOTOOLCHAIN: local
    GOLANGCI_LINT_OUTPUT_PATH: /tmp/golangci-lint.txt
Install govulncheck
  go: invalid GOTOOLCHAIN "null"
  Error: Process completed with exit code 1.
``` 

The error is somewhat misleading as there seems to be no way for `GOTOOLCHAIN` end up being "null" when `go install` runs. [See one example here](https://github.com/ubuntu/ubuntu-insights/actions/runs/26596853884/job/78369986955#step:4:690).

The most significant change in between the previous v2 and the current one is the upgrade of the `actions/setup-go` from v5 to v6. In this new version, that action sets `GOTOOLCHAIN` to `local` when invoked with a `go-version-file`. It seems that overwriting that environment variable breaks in GitHub Actions for environment specifics I'm not sure about the details.

But that's not all. If we adjust the snippet of code that manipulates the `GOTOOLCHAIN` environment variable, we still end up with `govulncheck` being invoked against a wrong version of the Go toolchain. That's because we don't set the precise toolchain version in `go.mod` files in a workspace, but rather at the parent `go.work`. So, the current implementation of the `go/code-sanity` action will always install the earliest toolchain of a minor Go version (like 1.25.0 or 1.26.0) and `govulncheck` will report vulnerabilities that are not in effect if the workspace is already using a newer toolchain (such as 1.25.10 or 1.26.3).

```
[57](https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/26598020426/job/78374066710#step:7:582)
Run # Install govulncheck
  # Install govulncheck
  echo "::group::Install govulncheck"
  TOOLCHAIN=$(go mod edit -json "/home/runner/work/ubuntu-pro-for-wsl/ubuntu-pro-for-wsl/tools/go.mod" | jq -r '.Toolchain')
  if [ "${TOOLCHAIN}" == "null" ]; then
    TOOLCHAIN="go$(go mod edit -json "/home/runner/work/ubuntu-pro-for-wsl/ubuntu-pro-for-wsl/tools/go.mod" | jq -r '.Go')"
  fi
  GOTOOLCHAIN=${TOOLCHAIN} \
    go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
  echo "::endgroup::"
  shell: /usr/bin/bash --noprofile --norc -euo pipefail {0}
  env:
    FLUTTER_ROOT: /opt/hostedtoolcache/flutter/stable-3.41.9-x64/flutter
    PUB_CACHE: /home/runner/.pub-cache
    GOTOOLCHAIN: local
    GOLANGCI_LINT_OUTPUT_PATH: /tmp/golangci-lint.txt
Install govulncheck
Run # govulncheck
=== Symbol Results ===

Vulnerability #1: GO-2026-4971
    Panic in Dial and LookupPort when handling NUL byte on Windows in net
  More info: https://pkg.go.dev/vuln/GO-2026-4971
  Standard library
    Found in: net@go1.26
    Fixed in: net@go1.26.3
    Example traces found:
Error:       #1: go/agentapi.pb.go:734:36: go.file_agentapi_proto_rawDescGZIP calls sync.Once.Do, which eventually calls net.Dialer.DialContext

Vulnerability #2: GO-2026-4947
    Unexpected work during chain building in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2026-4947
  Standard library
    Found in: crypto/x509@go1.26
    Fixed in: crypto/x509@go1.26.2
``` 

The proper fix for this seems to be accepting the `go.work` file as an input to `actions/setup-go`  so we can use the precise version of the toolchain declared there instead of the Go version present in a child module.

For completeness, it's worth noting that with `actions/setup-go@v5` that wasn't a problem because the action would setup the earliest toolchain of the minor Go version but then any go command inside the workspace would trigger a local installation of the correct toolchain version as defined in the `go.work` - wasteful in the sense that two installs would happen ( [see here for an example](https://github.com/canonical/ubuntu-pro-for-wsl/actions/runs/25488536723/job/74790296897#step:7:31) ).