### PR TITLE
fix: gh-actions/build-debian: Fix 'cd: null directory'

### DIFF
--- a/gh-actions/common/build-debian/action.yaml
+++ b/gh-actions/common/build-debian/action.yaml
@@ -114,7 +114,9 @@ runs:
       run: |
         echo "::group::Create local version with commit and docker container"
 
-        cd '${{ inputs.source-dir }}'
+        if [ -n "${{ inputs.source-dir }}" ]; then
+          cd '${{ inputs.source-dir }}'
+        fi
 
         # Short commit to avoid "package-has-long-file-name"
         VERSION_REF=$(date +'%y%m%d')+${{ github.run_number }}+$(echo ${{ github.sha }} | cut -c1-8)


### PR DESCRIPTION
On Resolute, using `cd ''` in bash fails. On Noble it did not.

UDENG-10958